### PR TITLE
server: require signed requests

### DIFF
--- a/lib/api.proto
+++ b/lib/api.proto
@@ -1,6 +1,27 @@
 package api;
 syntax = "proto3";
 
+message Credentials {
+  message Aws {
+    string accessKeyId = 1;
+    string secretAccessKey = 2;
+    string sessionToken = 3;
+    string expiration = 4;
+  }
+  message S3Post {
+    message PostData {
+      string AWSAccessKeyId = 1;
+      string policy = 2;
+      string signature = 3;
+      string acl = 4;
+    }
+    PostData postData = 1;
+    string bucket = 2;
+  }
+  Aws aws = 1;
+  S3Post s3Post = 2;
+}
+
 message SecretBoxRecord {
   bytes encryptedData = 1;
   int counter = 2;

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -38,3 +38,15 @@ Serializer.prototype.stringToByteArray = function (msg/* : string */) {
 Serializer.prototype.byteArrayToString = function (bytes/* : Uint8Array */) {
   return this.api.GenericMessage.decode(bytes).message
 }
+
+module.exports.serializer = null
+
+module.exports.initSerializer = function (apiFile/* : string */) {
+  return new Promise((resolve, reject) => {
+    if (this.serializer) { resolve(this.serializer) }
+    this.init(apiFile).then((serializer) => {
+      this.serializer = serializer
+      resolve(serializer)
+    }).catch((error) => { reject(error) })
+  })
+}

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -5,15 +5,20 @@ const pb = require('protobufjs')
 
 module.exports.init = function (apiFile/* : string */) {
   return pb.load(apiFile || './lib/api.proto').then((r) => {
-    return new Serializer({
+    if (this.serializer) { return this.serializer }
+    const serializer = new Serializer({
       GenericMessage: r.lookup('api.GenericMessage'),
       SecretBoxRecord: r.lookup('api.SecretBoxRecord'),
       SyncRecord: r.lookup('api.SyncRecord')
     })
+    this.serializer = serializer
+    return serializer
   }).catch((e) => {
     throw new Error('Proto file could not be loaded.')
   })
 }
+
+module.exports.serializer = null
 
 var Serializer = function (api) {
   this.api = api
@@ -37,16 +42,4 @@ Serializer.prototype.stringToByteArray = function (msg/* : string */) {
  */
 Serializer.prototype.byteArrayToString = function (bytes/* : Uint8Array */) {
   return this.api.GenericMessage.decode(bytes).message
-}
-
-module.exports.serializer = null
-
-module.exports.initSerializer = function (apiFile/* : string */) {
-  return new Promise((resolve, reject) => {
-    if (this.serializer) { resolve(this.serializer) }
-    this.init(apiFile).then((serializer) => {
-      this.serializer = serializer
-      resolve(serializer)
-    }).catch((error) => { reject(error) })
-  })
 }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -7,6 +7,7 @@ module.exports.init = function (apiFile/* : string */) {
   return pb.load(apiFile || './lib/api.proto').then((r) => {
     if (this.serializer) { return this.serializer }
     const serializer = new Serializer({
+      Credentials: r.lookup('api.Credentials'),
       GenericMessage: r.lookup('api.GenericMessage'),
       SecretBoxRecord: r.lookup('api.SecretBoxRecord'),
       SyncRecord: r.lookup('api.SyncRecord')
@@ -42,4 +43,25 @@ Serializer.prototype.stringToByteArray = function (msg/* : string */) {
  */
 Serializer.prototype.byteArrayToString = function (bytes/* : Uint8Array */) {
   return this.api.GenericMessage.decode(bytes).message
+}
+
+/**
+ * Serializes client sync credentials for accessing AWS and S3.
+ * @param {{aws: {{accessKeyId: <string>, secretAccessKey: <string>, sessionToken: <string>, expiration: <string>}}}, s3Post: {{bucket: <string>, postData: {{accessKeyId: <string>, secretAccessKey: <string>, sessionToken: <string>, expiration: <string>}}}}}} credentials
+ * @returns {Uint8Array}
+ */
+Serializer.prototype.credentialsToByteArray = function (credentials) {
+  return this.api.Credentials.encode({
+    aws: this.api.Credentials.lookup('Aws').create(credentials.aws),
+    s3Post: this.api.Credentials.lookup('S3Post').create(credentials.s3Post)
+  }).finish()
+}
+
+/**
+ * Deserializes client sync credentials for accessing AWS and S3.
+ * @param {Uint8Array} bytes
+ * @returns {api.Credentials}
+ */
+Serializer.prototype.byteArrayToCredentials = function (bytes) {
+  return this.api.Credentials.decode(bytes)
 }

--- a/package.json
+++ b/package.json
@@ -38,13 +38,11 @@
     "nsp": "^2.6.2",
     "pryjs": "^1.0.3",
     "standard": "^8.5.0",
-    "supertest": "^2.0.1",
-    "tape": "^4.6.3",
+    "tape": "^4.6.2",
     "timekeeper": "^1.0.0"
   },
   "dependencies": {
     "aws-sdk": "^2.7.7",
-    "body-parser": "^1.15.2",
     "config": "^1.24.0",
     "express": "^4.14.0",
     "protobufjs": "github:dcodeio/protobuf.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "nsp": "^2.6.2",
     "pryjs": "^1.0.3",
     "standard": "^8.5.0",
-    "tape": "^4.6.2",
+    "tape": "^4.6.3",
     "timekeeper": "^1.0.0"
   },
   "dependencies": {

--- a/server/config/custom-environment-variables.json
+++ b/server/config/custom-environment-variables.json
@@ -9,6 +9,7 @@
   /*"categoryIdPreferences": "\u0003",*/
   "logLevel": "LOG_LEVEL",
   "port": "PORT",
+  "serverUrl": "SERVER_URL",
   "userAgent": "USER_AGENT",
   "userAwsCredentialTtl": "USER_AWS_CREDENTIAL_TTL"
 }

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -7,8 +7,10 @@
   "categoryIdBookmarks": "\u0001",
   "categoryIdHistorySites": "\u0002",
   "categoryIdPreferences": "\u0003",
+  "clientTimestampOffsetMax": 120,
   "logLevel": "debug",
   "port": 4000,
+  "serverUrl": "http://localhost:4000",
   "userAgent": null,
   "userAwsCredentialTtl": 3600
 }

--- a/server/index.js
+++ b/server/index.js
@@ -3,12 +3,8 @@
 // Dependencies
 // ===
 
-const BodyParser = require('body-parser')
-
 // web server
 const Express = require('express')
-
-// const Querystring = require("querystring")
 
 // See config/
 const Config = require('config')
@@ -22,7 +18,6 @@ const Util = require('./lib/util.js')
 
 const app = Express()
 app.disable('x-powered-by')
-app.use(BodyParser.text({type: '*/*'}))
 if (Config.logLevel === 'debug') {
   app.use(Util.debugLogger)
 }

--- a/server/lib/request-verifier.js
+++ b/server/lib/request-verifier.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const config = require('config')
+const crypto = require('../../lib/crypto')
+const serializer = require('../../lib/serializer.js')
+serializer.initSerializer()
+
+/**
+ * Check if a client's reported timestamp is within the acceptable range.
+ * @param {number} timestamp
+ * @returns {boolean}
+ */
+function validTimestamp (timestamp) {
+  if (typeof timestamp !== 'number') { throw new Error('timestamp must be a number') }
+  const serverTimestamp = Math.floor(Date.now() / 1000)
+  const offset = Math.abs(serverTimestamp - timestamp)
+  return (offset < config.clientTimestampOffsetMax)
+}
+
+/**
+ * Verifies a request is signed with the correct public key.
+ * For use with express app.param().
+ */
+module.exports = function (request, response, next, userId) {
+  if (!userId) {
+    return response.status(400).end('userId (pubkey) is required (url syntax: /:userId/{endpoint}).')
+  }
+  let body = Buffer.alloc(0)
+  request.on('data', (chunk) => {
+    const totalLength = body.length + chunk.length
+    body = Buffer.concat([body, chunk], totalLength)
+  }).on('end', () => {
+    if (!body || body.length === 0) {
+      return response.status(400).end('Signed request body is required.')
+    }
+    const publicKey = Buffer.from(userId, 'base64')
+    const verifiedBytes = crypto.verify(body, publicKey)
+    if (!verifiedBytes) {
+      return response.status(400).end('Unable to verify the signed request. Please check the signing private key matches the pubkey.')
+    }
+
+    const result = serializer.serializer.byteArrayToString(verifiedBytes)
+    const timestamp = parseInt(result)
+
+    if (!result || !timestamp || !validTimestamp(timestamp)) {
+      return response.status(400).end('Signed request body of the client timestamp is required.')
+    }
+    request.userId = userId
+    next()
+  })
+}

--- a/server/lib/request-verifier.js
+++ b/server/lib/request-verifier.js
@@ -3,7 +3,7 @@
 const config = require('config')
 const crypto = require('../../lib/crypto')
 const serializer = require('../../lib/serializer.js')
-serializer.initSerializer()
+serializer.init()
 
 /**
  * Check if a client's reported timestamp is within the acceptable range.

--- a/server/lib/request-verifier.js
+++ b/server/lib/request-verifier.js
@@ -34,7 +34,11 @@ module.exports = function (request, response, next, userId) {
       return response.status(400).end('Signed request body is required.')
     }
     const publicKey = Buffer.from(userId, 'base64')
-    const verifiedBytes = crypto.verify(body, publicKey)
+
+    let verifiedBytes = null
+    try {
+      verifiedBytes = crypto.verify(body, publicKey)
+    } catch (e) {}
     if (!verifiedBytes) {
       return response.status(400).end('Unable to verify the signed request. Please check the signing private key matches the pubkey.')
     }

--- a/server/lib/user-aws-s3-post-authenticator.js
+++ b/server/lib/user-aws-s3-post-authenticator.js
@@ -23,7 +23,7 @@ class UserAwsS3PostAuthenticator {
       .digest('base64')
     return {
       bucket: this.s3Bucket,
-      postParams: {
+      postData: {
         AWSAccessKeyId: config.awsAccessKeyId,
         policy: s3PostPolicy,
         signature: policySignature,

--- a/server/users.js
+++ b/server/users.js
@@ -5,7 +5,7 @@ const requestVerifier = require('./lib/request-verifier.js')
 const router = Express.Router()
 const serializer = require('../lib/serializer.js')
 // TODO: This returns a Promise; we may want to block requests until it resolves
-serializer.initSerializer()
+serializer.init()
 
 const UserAwsCredentialGenerator = require('./lib/user-aws-credential-generator')
 const UserAwsS3PostAuthenticator = require('./lib/user-aws-s3-post-authenticator')

--- a/server/users.js
+++ b/server/users.js
@@ -25,8 +25,9 @@ router.post('/:userId/credentials', (request, response) => {
   })
 
   Promise.all([credentialPromise, postAuthenticatorPromise])
-    .then(([awsCredentials, s3PostParams]) => {
-      response.send({awsCredentials, s3PostParams})
+    .then(([aws, s3Post]) => {
+      const serialized = serializer.serializer.credentialsToByteArray({aws, s3Post})
+      response.send(serialized)
     })
     .catch((error) => { response.send(error) })
 })

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const crypto = require('../lib/crypto')
 const serializer = require('../lib/serializer')
 
-function initSerializer() {
+function init() {
   return serializer.init()
 }
 
@@ -177,7 +177,7 @@ test('encrypt and decrypt', (t) => {
   })
   t.test('decrypts to original message', (q) => {
     q.plan(1)
-    initSerializer().then((testSerializer) => {
+    init().then((testSerializer) => {
       const encrypted = crypto.encrypt(testSerializer.stringToByteArray(message), key, 0)
       const decrypted = crypto.decrypt(encrypted.ciphertext, encrypted.nonce, key)
       q.equal(message, testSerializer.byteArrayToString(decrypted))
@@ -185,7 +185,7 @@ test('encrypt and decrypt', (t) => {
   })
   t.test('decryption failures', (q) => {
     q.plan(3)
-    initSerializer().then((testSerializer) => {
+    init().then((testSerializer) => {
       const encrypted = crypto.encrypt(testSerializer.stringToByteArray(message), key, 0)
       q.equal(crypto.decrypt(encrypted.ciphertext, new Uint8Array(24), key), false)
       q.equal(crypto.decrypt(encrypted.ciphertext, encrypted.nonce, new Uint8Array(32)), false)
@@ -207,7 +207,7 @@ test('key derivation', (t) => {
   const message = '€ 123 ッッッ　あ'
   t.test('can encrypt and decrypt with the derived key', (q) => {
     q.plan(1)
-    initSerializer().then((testSerializer) => {
+    init().then((testSerializer) => {
       const encrypted = crypto.encrypt(testSerializer.stringToByteArray(message),
         key.secretboxKey, 1)
       const decrypted = crypto.decrypt(encrypted.ciphertext, encrypted.nonce,
@@ -218,7 +218,7 @@ test('key derivation', (t) => {
   t.test('can sign and verify with the derived key', (q) => {
     q.plan(4)
     // XXX: bytes is length 25 in node and 47 in browser!
-    initSerializer().then((testSerializer) => {
+    init().then((testSerializer) => {
       const bytes = testSerializer.stringToByteArray(message)
       const signed = crypto.sign(bytes, key.secretKey)
       q.equal(signed.length, bytes.length + 64)

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -19,3 +19,48 @@ test('serializing strings', (t) => {
     })
   })
 })
+
+test('serializing aws and s3 credentials', (t) => {
+  t.plan(4)
+
+  const credentials = {
+    aws: {
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      sessionToken: 'AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE',
+      expiration: '2015-04-20T13:37:00.000Z'
+    },
+    s3Post: {
+      bucket: 'cool-bucket',
+      postData: {
+        AWSAccessKeyId: 'AKIAIOSFODNN7EXAMPL3',
+        policy: '{"expiration": "2015-04-20T13:37:00.000Z","conditions": [{"bucket": "cool-bucket"}',
+        signature: 'something really secret todo we could validate it',
+        acl: 'private'
+      }
+    }
+  }
+
+  serializer.init().then((serializer) => {
+    const serialized = serializer.credentialsToByteArray(credentials)
+    const serializedClass = Object.prototype.toString.call(serialized)
+    t.equal(serializedClass, '[object Uint8Array]', 'serializes credentials')
+
+    const deserialized = serializer.byteArrayToCredentials(serialized)
+    t.equal(
+      deserialized.$type,
+      serializer.api.Credentials,
+      'deserializes to api.Credentials protobuf type'
+    )
+    t.equal(
+      deserialized.aws.$type,
+      serializer.api.Credentials.lookup('Aws'),
+      'credentials include api.Credentials.Aws protobuf type'
+    )
+    t.equal(
+      deserialized.s3Post.$type,
+      serializer.api.Credentials.lookup('S3Post'),
+      'credentials include api.Credentials.S3Post protobuf type'
+    )
+  })
+})

--- a/test/server/lib/request-verifier.js
+++ b/test/server/lib/request-verifier.js
@@ -1,0 +1,84 @@
+const test = require('tape')
+const crypto = require('../../../lib/crypto')
+const request = require('request')
+const requestVerifier = require('../../../server/lib/request-verifier.js')
+const serializer = require('../../../lib/serializer.js')
+const Express = require('express')
+
+test('users router', (t) => {
+  const app = Express()
+  app.param('userId', requestVerifier)
+  app.post('/:userId/', (_request, response) => { response.send('sweet') })
+
+  const server = app.listen(0, 'localhost', () => {
+    serializer.initSerializer().then(() => {
+      const serverUrl = `http://localhost:${server.address().port}`
+      console.log(`server up on ${serverUrl}`)
+
+      const keys = crypto.deriveKeys(crypto.getSeed())
+      const userId = Buffer.from(keys.publicKey).toString('base64')
+      const baseRequest = request.defaults({
+        baseUrl: `${serverUrl}/${encodeURIComponent(userId)}`
+      })
+
+      function signedTimestamp (secretKey, timestamp) {
+        if (!timestamp) { timestamp = Math.floor(Date.now() / 1000) }
+        const message = timestamp.toString()
+        return crypto.sign(serializer.serializer.stringToByteArray(message), secretKey)
+      }
+
+      const sharedParams = { method: 'POST', url: '/' }
+      baseRequest(sharedParams, (_error, response, body) => {
+        if (response.statusCode >= 400 && response.statusCode <= 499) {
+          t.pass('fails without signed timestamp')
+        } else {
+          t.fail('should not work')
+        }
+      })
+
+      const keysTwo = crypto.deriveKeys(crypto.getSeed())
+      const mismatchParams = Object.assign(
+        sharedParams,
+        { body: Buffer.from(signedTimestamp(keysTwo.secretKey).buffer) }
+      )
+      baseRequest(mismatchParams, (_error, response, body) => {
+        if (response.statusCode >= 400 && response.statusCode <= 499) {
+          t.pass('fails without signature mismatches URL pubkey')
+        } else {
+          t.fail('should not work')
+        }
+      })
+
+      const oldTimestamp = Math.floor(Date.now() / 1000) - 60 * 60
+      const oldParams = Object.assign(
+        sharedParams,
+        { body: Buffer.from(signedTimestamp(keys.secretKey, oldTimestamp).buffer) }
+      )
+      baseRequest(oldParams, (_error, response, body) => {
+        if (response.statusCode >= 400 && response.statusCode <= 499) {
+          t.pass('fails with a properly signed old timestamp')
+        } else {
+          t.fail('should not work')
+        }
+      })
+
+      const legitParams = Object.assign(
+        sharedParams,
+        { body: Buffer.from(signedTimestamp(keys.secretKey).buffer) }
+      )
+      baseRequest(legitParams, (_error, response, body) => {
+        if (response.statusCode >= 200 && response.statusCode <= 299) {
+          t.pass('works when signed correctly')
+        } else {
+          t.fail('should work')
+        }
+
+        t.end()
+      })
+    })
+  })
+
+  test.onFinish(() => {
+    server.close()
+  })
+})

--- a/test/server/lib/request-verifier.js
+++ b/test/server/lib/request-verifier.js
@@ -11,7 +11,7 @@ test('users router', (t) => {
   app.post('/:userId/', (_request, response) => { response.send('sweet') })
 
   const server = app.listen(0, 'localhost', () => {
-    serializer.initSerializer().then(() => {
+    serializer.init().then(() => {
       const serverUrl = `http://localhost:${server.address().port}`
       console.log(`server up on ${serverUrl}`)
 

--- a/test/server/lib/request-verifier.js
+++ b/test/server/lib/request-verifier.js
@@ -6,6 +6,8 @@ const serializer = require('../../../lib/serializer.js')
 const Express = require('express')
 
 test('users router', (t) => {
+  t.plan(4)
+
   const app = Express()
   app.param('userId', requestVerifier)
   app.post('/:userId/', (_request, response) => { response.send('sweet') })
@@ -72,8 +74,6 @@ test('users router', (t) => {
         } else {
           t.fail('should work')
         }
-
-        t.end()
       })
     })
   })

--- a/test/server/lib/user-aws-s3-post-authenticator.js
+++ b/test/server/lib/user-aws-s3-post-authenticator.js
@@ -9,12 +9,16 @@ const util = require('../../../server/lib/util.js')
 const UserAwsS3PostAuthenticator = require('../../../server/lib/user-aws-s3-post-authenticator.js')
 
 test('userAwsS3PostAuthenticator', (t) => {
+  t.plan(2)
+
   t.throws(
     () => { return new UserAwsS3PostAuthenticator() },
     'requires userId'
   )
 
   t.test('perform()', (t) => {
+    t.plan(8)
+
     const adminS3 = new awsSdk.S3({
       credentials: new awsSdk.Credentials({
         accessKeyId: config.awsAccessKeyId,
@@ -36,6 +40,8 @@ test('userAwsS3PostAuthenticator', (t) => {
     t.assert(result.postData, 'returns post params')
 
     t.test('works: uploading sync records (historySites)', (t) => {
+      t.plan(1)
+
       const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
       const formData = Object.assign(
         {},
@@ -60,10 +66,11 @@ test('userAwsS3PostAuthenticator', (t) => {
           Key: `${apiVersion}/${userId}`
         })
       })
-      t.end()
     })
 
     t.test('works: uploading sync records (bookmarks)', (t) => {
+      t.plan(1)
+
       const objectKey = `${apiVersion}/${userId}/${categoryIdBookmarks}/1234/objectData`
       const formData = Object.assign(
         {},
@@ -88,10 +95,11 @@ test('userAwsS3PostAuthenticator', (t) => {
           Key: `${apiVersion}/${userId}`
         })
       })
-      t.end()
     })
 
     t.test('works: uploading sync records (preferences)', (t) => {
+      t.plan(1)
+
       const objectKey = `${apiVersion}/${userId}/${categoryIdPreferences}/1234/objectData`
       const formData = Object.assign(
         {},
@@ -116,10 +124,11 @@ test('userAwsS3PostAuthenticator', (t) => {
           Key: `${apiVersion}/${userId}`
         })
       })
-      t.end()
     })
 
     t.test('deny: uploading sync records with expired signed params', (t) => {
+      t.plan(1)
+
       timekeeper.freeze(new Date().getTime() - config.userAwsCredentialTtl * 1000)
       const result = new UserAwsS3PostAuthenticator(userId).perform()
       timekeeper.reset()
@@ -141,11 +150,11 @@ test('userAwsS3PostAuthenticator', (t) => {
           t.pass(t.name)
         }
       })
-
-      t.end()
     })
 
     t.test('deny: uploading to another user\'s prefix', (t) => {
+      t.plan(1)
+
       const keysTwo = crypto.deriveKeys(crypto.getSeed())
       const userIdTwo = Buffer.from(keysTwo.publicKey).toString('base64')
       const objectKey = `${apiVersion}/${userIdTwo}/${categoryIdHistorySites}/1234/objectData`
@@ -165,10 +174,11 @@ test('userAwsS3PostAuthenticator', (t) => {
           t.pass(t.name)
         }
       })
-      t.end()
     })
 
     t.test('deny: uploading objects with content', (t) => {
+      t.plan(1)
+
       const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
       const formData = Object.assign(
         {},
@@ -186,9 +196,6 @@ test('userAwsS3PostAuthenticator', (t) => {
           t.pass(t.name)
         }
       })
-      t.end()
     })
-
-    t.end()
   })
 })

--- a/test/server/lib/user-aws-s3-post-authenticator.js
+++ b/test/server/lib/user-aws-s3-post-authenticator.js
@@ -129,7 +129,7 @@ test('userAwsS3PostAuthenticator', (t) => {
     t.test('deny: uploading sync records with expired signed params', (t) => {
       t.plan(1)
 
-      timekeeper.freeze(new Date().getTime() - config.userAwsCredentialTtl * 1000)
+      timekeeper.freeze(new Date().getTime() - config.userAwsCredentialTtl * 1000 - 60 * 1000)
       const result = new UserAwsS3PostAuthenticator(userId).perform()
       timekeeper.reset()
 

--- a/test/server/lib/user-aws-s3-post-authenticator.js
+++ b/test/server/lib/user-aws-s3-post-authenticator.js
@@ -33,14 +33,14 @@ test('userAwsS3PostAuthenticator', (t) => {
     const service = new UserAwsS3PostAuthenticator(userId)
     result = service.perform()
     t.equals(result.bucket, config.awsS3Bucket, 'returns S3 bucket')
-    t.assert(result.postParams, 'returns post params')
+    t.assert(result.postData, 'returns post params')
 
     t.test('works: uploading sync records (historySites)', (t) => {
       const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([]) }
       )
       request.post({
@@ -68,7 +68,7 @@ test('userAwsS3PostAuthenticator', (t) => {
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([]) }
       )
       request.post({
@@ -96,7 +96,7 @@ test('userAwsS3PostAuthenticator', (t) => {
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([]) }
       )
       request.post({
@@ -128,7 +128,7 @@ test('userAwsS3PostAuthenticator', (t) => {
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([]) }
       )
       request.post({
@@ -152,7 +152,7 @@ test('userAwsS3PostAuthenticator', (t) => {
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([1, 2, 3]) }
       )
       request.post({
@@ -173,7 +173,7 @@ test('userAwsS3PostAuthenticator', (t) => {
       const formData = Object.assign(
         {},
         { key: objectKey },
-        result.postParams,
+        result.postData,
         { file: new Buffer([1, 2, 3]) }
       )
       request.post({

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -3,90 +3,122 @@ const awsSdk = require('aws-sdk')
 const config = require('config')
 const crypto = require('../../lib/crypto')
 const request = require('request')
-const supertest = require('supertest')
+const serializer = require('../../lib/serializer.js')
 const usersRouter = require('../../server/users.js')
 const util = require('../../server/lib/util.js')
 const Express = require('express')
 
 test('users router', (t) => {
-  const apiVersion = config.apiVersion
-  const categoryIdHistorySites = config.categoryIdHistorySites
   const app = Express()
   app.use('/', usersRouter)
-  t.test('POST /:userId/credentials', (t) => {
-    // TODO: Make this deterministic for tests
-    const keys = crypto.deriveKeys(crypto.getSeed())
-    const s3Bucket = config.awsS3Bucket
-    const userId = Buffer.from(keys.publicKey).toString('base64')
+  const server = app.listen(0, 'localhost', () => {
+    serializer.initSerializer().then(() => {
+      const serverUrl = `http://localhost:${server.address().port}`
+      console.log(`server up on ${serverUrl}`)
 
-    supertest(app).post(`/${encodeURIComponent(userId)}/credentials`).end((error, response) => {
-      if (error) {
-        return t.fail(`${t.name} ${error} ${response}`)
-      }
-      t.equals(response.statusCode, 200, `${t.name} HTTP 200`)
-      const body = response.body
-      const credentials = body.credentials
-      t.assert(credentials, 'response has aws credentials')
-      const s3PostParams = body.s3PostParams
-      t.assert(s3PostParams, 'response has s3 post params')
-
-      t.test('aws credentials', (t) => {
-        const s3 = new awsSdk.S3({
-          credentials: new awsSdk.Credentials({
-            accessKeyId: credentials.accessKeyId,
-            secretAccessKey: credentials.secretAccessKey,
-            sessionToken: credentials.sessionToken
-          })
-        })
-        t.test('allow: s3 listObjectsV2 {apiVersion}/{userId}/*', (t) => {
-          s3.listObjectsV2({
-            Bucket: s3Bucket,
-            Prefix: `${apiVersion}/${userId}/`
-          }).promise()
-            .then((data) => { t.assert(data.Contents, t.name) })
-            .catch((data) => { t.fail(t.name) })
-          t.end()
-        })
-        t.end()
+      const keys = crypto.deriveKeys(crypto.getSeed())
+      const userId = Buffer.from(keys.publicKey).toString('base64')
+      const baseRequest = request.defaults({
+        baseUrl: `${serverUrl}/${encodeURIComponent(userId)}`
       })
 
-      t.test('s3 post params', (t) => {
-        const adminS3 = new awsSdk.S3({
-          credentials: new awsSdk.Credentials({
-            accessKeyId: config.awsAccessKeyId,
-            secretAccessKey: config.awsSecretAccessKey
-          })
+      const apiVersion = config.apiVersion
+      const categoryIdHistorySites = config.categoryIdHistorySites
+      const s3Bucket = config.awsS3Bucket
+
+      function signedTimestamp (secretKey, timestamp) {
+        if (!timestamp) { timestamp = Math.floor(Date.now() / 1000) }
+        const message = timestamp.toString()
+        return crypto.sign(serializer.serializer.stringToByteArray(message), secretKey)
+      }
+
+      t.test('POST /:userId/credentials', (t) => {
+        const sharedParams = { method: 'POST', url: '/credentials' }
+        baseRequest(sharedParams, (_error, response, body) => {
+          if (response.statusCode >= 400 && response.statusCode <= 499) {
+            t.pass('required signed timestamp')
+          } else {
+            t.fail('should not work')
+          }
         })
 
-        t.test('works: uploading sync records (historySites)', (t) => {
-          const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
-          const formData = Object.assign(
-            {},
-            { key: objectKey },
-            s3PostParams.postParams,
-            { file: new Buffer([]) }
-          )
-          request.post({
-            url: util.awsS3Endpoint(),
-            formData: formData
-          }, (_error, response, body) => {
-            if (response.statusCode >= 200 && response.statusCode <= 299) {
-              t.pass(t.name)
-            } else {
-              t.fail(`${t.name} (${response.statusCode}) (${body})`)
-            }
+        const params = Object.assign(
+          sharedParams,
+          { body: Buffer.from(signedTimestamp(keys.secretKey).buffer) }
+        )
+        baseRequest(params, (error, response, body) => {
+          if (error) { return t.fail(`${t.name} ${error} ${response}`) }
+          t.equals(response.statusCode, 200, `${t.name} -> 200`)
+
+          // TODO: Use protobuf?
+          const parsedBody = JSON.parse(response.body)
+          const credentials = parsedBody.awsCredentials
+          t.assert(credentials, 'response has aws credentials')
+          const s3PostParams = parsedBody.s3PostParams
+          t.assert(s3PostParams, 'response has s3 post params')
+
+          t.test('aws credentials', (t) => {
+            const s3 = new awsSdk.S3({
+              credentials: new awsSdk.Credentials({
+                accessKeyId: credentials.accessKeyId,
+                secretAccessKey: credentials.secretAccessKey,
+                sessionToken: credentials.sessionToken
+              })
+            })
+            t.test('allow: s3 listObjectsV2 {apiVersion}/{userId}/*', (t) => {
+              s3.listObjectsV2({
+                Bucket: s3Bucket,
+                Prefix: `${apiVersion}/${userId}/`
+              }).promise()
+                .then((data) => { t.assert(data.Contents, t.name) })
+                .catch((data) => { t.fail(t.name) })
+              t.end()
+            })
+            t.end()
           })
 
-          test.onFinish(() => {
-            adminS3.deleteObject({
-              Bucket: config.awsS3Bucket,
-              Key: `${apiVersion}/${userId}`
+          t.test('s3 post params', (t) => {
+            const adminS3 = new awsSdk.S3({
+              credentials: new awsSdk.Credentials({
+                accessKeyId: config.awsAccessKeyId,
+                secretAccessKey: config.awsSecretAccessKey
+              })
+            })
+
+            t.test('works: uploading sync records (historySites)', (t) => {
+              const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
+              const formData = Object.assign(
+                {},
+                { key: objectKey },
+                s3PostParams.postParams,
+                { file: new Buffer([]) }
+              )
+              request.post({
+                url: util.awsS3Endpoint(),
+                formData: formData
+              }, (_error, response, body) => {
+                if (response.statusCode >= 200 && response.statusCode <= 299) {
+                  t.pass(t.name)
+                } else {
+                  t.fail(`${t.name} (${response.statusCode}) (${body})`)
+                }
+              })
+
+              test.onFinish(() => {
+                adminS3.deleteObject({
+                  Bucket: config.awsS3Bucket,
+                  Key: `${apiVersion}/${userId}`
+                })
+              })
+              t.end()
             })
           })
-          t.end()
         })
       })
     })
   })
-  t.end()
+
+  test.onFinish(() => {
+    server.close()
+  })
 })

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -9,6 +9,8 @@ const util = require('../../server/lib/util.js')
 const Express = require('express')
 
 test('users router', (t) => {
+  t.plan(1)
+
   const app = Express()
   app.use('/', usersRouter)
   const server = app.listen(0, 'localhost', () => {
@@ -33,6 +35,8 @@ test('users router', (t) => {
       }
 
       t.test('POST /:userId/credentials', (t) => {
+        t.plan(6)
+
         const sharedParams = {
           encoding: null,
           method: 'POST',
@@ -61,6 +65,8 @@ test('users router', (t) => {
           t.assert(s3PostData, 'response has s3 post params')
 
           t.test('aws credentials', (t) => {
+            t.plan(1)
+
             const s3 = new awsSdk.S3({
               credentials: new awsSdk.Credentials({
                 accessKeyId: credentials.accessKeyId,
@@ -69,15 +75,15 @@ test('users router', (t) => {
               })
             })
             t.test('allow: s3 listObjectsV2 {apiVersion}/{userId}/*', (t) => {
+              t.plan(1)
+
               s3.listObjectsV2({
                 Bucket: s3Bucket,
                 Prefix: `${apiVersion}/${userId}/`
               }).promise()
                 .then((data) => { t.assert(data.Contents, t.name) })
                 .catch((data) => { t.fail(t.name) })
-              t.end()
             })
-            t.end()
           })
 
           t.test('s3 post params', (t) => {
@@ -89,6 +95,8 @@ test('users router', (t) => {
             })
 
             t.test('works: uploading sync records (historySites)', (t) => {
+              t.plan(1)
+
               const objectKey = `${apiVersion}/${userId}/${categoryIdHistorySites}/1234/objectData`
               const formData = Object.assign(
                 {},
@@ -113,7 +121,6 @@ test('users router', (t) => {
                   Key: `${apiVersion}/${userId}`
                 })
               })
-              t.end()
             })
           })
         })

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -12,7 +12,7 @@ test('users router', (t) => {
   const app = Express()
   app.use('/', usersRouter)
   const server = app.listen(0, 'localhost', () => {
-    serializer.initSerializer().then(() => {
+    serializer.init().then(() => {
       const serverUrl = `http://localhost:${server.address().port}`
       console.log(`server up on ${serverUrl}`)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,7 +200,7 @@ async@1.x, async@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
 
-async@^1.4.0, async@^1.5.2:
+async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -270,21 +270,6 @@ block-stream@*:
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
-
-body-parser@^1.15.2:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.15.2.tgz#d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67"
-  dependencies:
-    bytes "2.4.0"
-    content-type "~1.0.2"
-    debug "~2.2.0"
-    depd "~1.1.0"
-    http-errors "~1.5.0"
-    iconv-lite "0.4.13"
-    on-finished "~2.3.0"
-    qs "6.2.0"
-    raw-body "~2.1.7"
-    type-is "~1.6.13"
 
 boom@2.x.x:
   version "2.10.1"
@@ -450,10 +435,6 @@ builtin-status-codes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz#6f22003baacf003ccd287afe6872151fddc58579"
 
-bytes@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
-
 cached-path-relative@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.0.tgz#d1094c577fbd9a8b8bd43c96af6188aa205d05f4"
@@ -593,10 +574,6 @@ commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-component-emitter@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -661,10 +638,6 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-
-cookiejar@^2.0.6:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.0.tgz#86549689539b6d0e269b6637a304be508194d898"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1187,7 +1160,7 @@ express@^4.14.0:
     utils-merge "1.0.0"
     vary "~1.1.0"
 
-extend@3, extend@^3.0.0, extend@~3.0.0:
+extend@3, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -1288,14 +1261,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@1.0.0-rc4:
-  version "1.0.0-rc4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.0-rc4.tgz#05ac6bc22227b43e4461f488161554699d4f8b5e"
-  dependencies:
-    async "^1.5.2"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.10"
-
 form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
@@ -1303,10 +1268,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formidable@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -1564,10 +1525,6 @@ https-proxy-agent@^1.0.0:
     agent-base "2"
     debug "2"
     extend "3"
-
-iconv-lite@0.4.13:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -2053,7 +2010,7 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-methods@1.x, methods@^1.1.1, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -2086,13 +2043,13 @@ mime-db@~1.25.0:
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
 
-mime-types@^2.1.10, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
   dependencies:
     mime-db "~1.25.0"
 
-mime@1.3.4, mime@^1.3.4:
+mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
@@ -2518,7 +2475,7 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
-qs@^6.1.0, qs@~6.3.0:
+qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
@@ -2545,14 +2502,6 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@~2.1.7:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.1.7.tgz#adfeace2e4fb3098058014d08c072dcc59758774"
-  dependencies:
-    bytes "2.4.0"
-    iconv-lite "0.4.13"
-    unpipe "1.0.0"
-
 rc@^1.0.1, rc@^1.1.2, rc@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.6.tgz#43651b76b6ae53b5c802f1151fa3fc3b059969c9"
@@ -2575,7 +2524,7 @@ read-only-stream@^2.0.0:
   dependencies:
     readable-stream "^2.0.2"
 
-readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -3041,28 +2990,6 @@ subcommand@^2.0.3:
     minimist "^1.2.0"
     xtend "^4.0.0"
 
-superagent@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
-  dependencies:
-    component-emitter "^1.2.0"
-    cookiejar "^2.0.6"
-    debug "^2.2.0"
-    extend "^3.0.0"
-    form-data "1.0.0-rc4"
-    formidable "^1.0.17"
-    methods "^1.1.1"
-    mime "^1.3.4"
-    qs "^6.1.0"
-    readable-stream "^2.0.5"
-
-supertest@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-2.0.1.tgz#a058081d788f1515d4700d7502881e6b759e44cd"
-  dependencies:
-    methods "1.x"
-    superagent "^2.0.0"
-
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
@@ -3257,7 +3184,7 @@ uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 


### PR DESCRIPTION
- Adds `request-verifier` which verifies signed timestamp in request bodies.
- Uses `request-verifier` to verify requests to `POST /{userId}/credentials`.

auditors: @diracdeltas 