### PR TITLE
Add SyncRecord.siteSetting.fields

### DIFF
--- a/client/recordUtil.js
+++ b/client/recordUtil.js
@@ -183,6 +183,13 @@ module.exports.resolveRecords = (recordsAndExistingObjects) => {
   return resolvedRecords
 }
 
+const pickFields = (object, fields) => {
+  return fields.reduce((a, x) => {
+    if (object.hasOwnProperty(x)) { a[x] = object[x] }
+    return a
+  }, {})
+}
+
 /**
  * Given a SyncRecord protobuf object, convert to a basic JS object.
  * @param {Serializer.api.SyncRecord}
@@ -196,8 +203,13 @@ module.exports.syncRecordAsJS = (record) => {
    */
   let object = record.toObject()
   object.action = record.action
-  const objectData = serializer.getSyncRecordObjectData(record)
-  object.objectData = objectData
-  object[objectData] = record[objectData].toObject({defaults: true, enums: Number, longs: Number})
+  const type = serializer.getSyncRecordObjectData(record)
+  object.objectData = type
+  const data = record[type].toObject({defaults: true, enums: Number, longs: Number})
+  if (data.fields && data.fields.length > 0) {
+    object[type] = pickFields(data, data.fields)
+  } else {
+    object[type] = data
+  }
   return object
 }

--- a/lib/api.proto
+++ b/lib/api.proto
@@ -66,6 +66,7 @@ message SyncRecord {
     bool fingerprintingProtection = 9;
     bool ledgerPayments = 10;
     bool ledgerPaymentsShown = 11;
+    repeated string fields = 12;
   }
   message Device {
     string name = 1;

--- a/lib/api.proto.js
+++ b/lib/api.proto.js
@@ -1814,6 +1814,12 @@
                  */
                 SiteSetting.prototype.ledgerPaymentsShown = false;
     
+                /**
+                 * SiteSetting fields.
+                 * @type {Array.<string>}
+                 */
+                SiteSetting.prototype.fields = $util.emptyArray;
+    
                 // Lazily resolved type references
                 var $types = {
                     3: "api.SyncRecord.SiteSetting.AdControl",
@@ -1860,6 +1866,9 @@
                         writer.uint32(/* id 10, wireType 0 =*/80).bool(message.ledgerPayments);
                     if (message.ledgerPaymentsShown !== undefined && message.hasOwnProperty("ledgerPaymentsShown"))
                         writer.uint32(/* id 11, wireType 0 =*/88).bool(message.ledgerPaymentsShown);
+                    if (message.fields !== undefined && message.hasOwnProperty("fields"))
+                        for (var i = 0; i < message.fields.length; ++i)
+                            writer.uint32(/* id 12, wireType 2 =*/98).string(message.fields[i]);
                     return writer;
                 };
     
@@ -1918,6 +1927,11 @@
                             break;
                         case 11:
                             message.ledgerPaymentsShown = reader.bool();
+                            break;
+                        case 12:
+                            if (!(message.fields && message.fields.length))
+                                message.fields = [];
+                            message.fields.push(reader.string());
                             break;
                         default:
                             reader.skipType(tag & 7);
@@ -1988,6 +2002,13 @@
                     if (message.ledgerPaymentsShown !== undefined)
                         if (typeof message.ledgerPaymentsShown !== "boolean")
                             return "ledgerPaymentsShown: boolean expected";
+                    if (message.fields !== undefined) {
+                        if (!Array.isArray(message.fields))
+                            return "fields: array expected";
+                        for (var i = 0; i < message.fields.length; ++i)
+                            if (!$util.isString(message.fields[i]))
+                                return "fields: string[] expected";
+                    }
                     return null;
                 };
     
@@ -2040,6 +2061,11 @@
                         message.ledgerPayments = Boolean(object.ledgerPayments);
                     if (object.ledgerPaymentsShown !== undefined && object.ledgerPaymentsShown !== null)
                         message.ledgerPaymentsShown = Boolean(object.ledgerPaymentsShown);
+                    if (object.fields) {
+                        message.fields = [];
+                        for (var i = 0; i < object.fields.length; ++i)
+                            message.fields[i] = String(object.fields[i]);
+                    }
                     return message;
                 };
     
@@ -2061,6 +2087,8 @@
                     if (!options)
                         options = {};
                     var object = {};
+                    if (options.arrays || options.defaults)
+                        object.fields = [];
                     if (options.defaults) {
                         object.hostPattern = "";
                         object.zoomLevel = 0;
@@ -2096,6 +2124,11 @@
                         object.ledgerPayments = message.ledgerPayments;
                     if (message.ledgerPaymentsShown !== undefined && message.ledgerPaymentsShown !== null && message.hasOwnProperty("ledgerPaymentsShown"))
                         object.ledgerPaymentsShown = message.ledgerPaymentsShown;
+                    if (message.fields !== undefined && message.fields !== null && message.hasOwnProperty("fields")) {
+                        object.fields = [];
+                        for (var j = 0; j < message.fields.length; ++j)
+                            object.fields[j] = message.fields[j];
+                    }
                     return object;
                 };
     

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -121,12 +121,16 @@ Serializer.prototype.syncRecordToByteArray = function (record) {
   if (!type) {
     throw new Error('Unsupported sync data type.')
   }
+  const typeProps = Object.assign({}, record[type])
+  if (type === 'siteSetting') {
+    typeProps.fields = Object.keys(record[type])
+  }
   return this.api.SyncRecord.encode({
     action: record.action,
     deviceId: record.deviceId,
     objectData: type,
     objectId: record.objectId,
-    [type]: this.api.SyncRecord[syncTypes[type]].create(record[type])
+    [type]: this.api.SyncRecord[syncTypes[type]].create(typeProps)
   }).finish()
 }
 

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -308,8 +308,8 @@ test('recordUtil.syncRecordAsJS()', (t) => {
     }
     const conversionEquals = (recordProps) => {
       const props = Object.assign({}, baseProps, recordProps)
-      const encodedRecord = serializer.api.SyncRecord.encode(props).finish()
-      const decodedRecord = serializer.api.SyncRecord.decode(encodedRecord)
+      const encodedRecord = serializer.syncRecordToByteArray(props)
+      const decodedRecord = serializer.byteArrayToSyncRecord(encodedRecord)
       const recordJS = recordUtil.syncRecordAsJS(decodedRecord)
       t.deepEquals(recordJS, props, `${t.name} ${recordProps.objectData}`)
     }
@@ -331,9 +331,8 @@ test('recordUtil.syncRecordAsJS()', (t) => {
     })
     conversionEquals({ objectData: 'bookmark', bookmark })
 
-    // All params are required because protobufs assume undefined == default value
     const siteSetting = serializer.api.SyncRecord.SiteSetting.create({
-      adControl: 0, cookieControl: 0, fingerprintingProtection: false, hostPattern: 'https://jisho.org', httpsEverywhere: false, ledgerPayments: false, ledgerPaymentsShown: false, noScript: false, safeBrowsing: false, shieldsUp: false, zoomLevel: 0.5
+      hostPattern: 'https://jisho.org', httpsEverywhere: false, ledgerPayments: false, ledgerPaymentsShown: false, noScript: false, safeBrowsing: false, shieldsUp: false, zoomLevel: 0.5
     })
     conversionEquals({ objectData: 'siteSetting', siteSetting })
 


### PR DESCRIPTION
Currently you can't encode a siteSetting with just a single setting . For example, a SyncRecord with `siteSetting: {shieldsUp: true}` encoded and decoded returns additionally *all* the siteSetting fields's defaults. This is because proto3 doesn't distinguish between fields set to default values and unset fields.

This PR adds the `SyncRecord.siteSetting.fields` with which we'll specify the changed fields. This is similar to [google.protobuf.Fieldmask](https://github.com/dcodeIO/protobuf.js/blob/master/google/protobuf/field_mask.proto).

recordUtil.syncRecordAsJS() will take `fields` into account when converting records back to the browser client format.