### PR TITLE
Use ms precision for record timestamps in S3 key 

### DIFF
--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -29,10 +29,6 @@ const isExpiredCredentialError = (error) => {
   })
 }
 
-const getTime = () => {
-  return Math.floor(Date.now() / 1000)
-}
-
 /**
  * @param {{
  *   apiVersion: <string>,
@@ -68,7 +64,8 @@ const RequestUtil = function (opts = {}) {
  * @return {Promise} After it resolves, the object is ready to make requests.
  */
 RequestUtil.prototype.refreshAWSCredentials = function () {
-  const timestampString = getTime().toString()
+  // Timestamp checked in server/lib/request-verifier.js
+  const timestampString = Math.floor(Date.now() / 1000).toString()
   const userId = window.encodeURIComponent(this.userId)
   const url = `${this.serverUrl}/${userId}/credentials`
   const bytes = this.serializer.stringToByteArray(timestampString)
@@ -196,7 +193,7 @@ RequestUtil.prototype.list = function (category, startAt) {
  * @returns {string}
  */
 RequestUtil.prototype.currentRecordPrefix = function (category) {
-  return `${this.apiVersion}/${this.userId}/${category}/${getTime()}/`
+  return `${this.apiVersion}/${this.userId}/${category}/${Date.now()}/`
 }
 
 /**

--- a/test/s3Helper.js
+++ b/test/s3Helper.js
@@ -18,7 +18,7 @@ test('s3Helper', (t) => {
 
   t.test('encodeDataToS3KeyArray / parseS3Key', (t) => {
     t.plan(3)
-    const s3Prefix = '0/xGrUe8vokl9kjAx+RTu9t6I1UnOT7mcdcizAVI+2bos=/2/1482435340'
+    const s3Prefix = '0/xGrUe8vokl9kjAx+RTu9t6I1UnOT7mcdcizAVI+2bos=/2/1482435340000'
 
     t.test(`${t.name}: small data`, (t) => {
       t.plan(3)


### PR DESCRIPTION
Fix #53

This uses 3 bytes per S3 key, however with multi-part records we still support up to ~50 KiB per record.