### PR TITLE
WIP: Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:alpine
+
+# Prepare application 
+RUN mkdir -p /app
+
+# Add source code to container
+COPY ./ /app
+
+# Change workdir to applications folder
+WORKDIR /app
+
+# Install brave-sync's dependencies
+RUN yarn install \
+	&& yarn run build
+
+# Expose default port
+EXPOSE 4000
+
+# Populate config dir as volume to persist changes
+VOLUME /app/server/config
+
+# Define container command
+CMD ["/usr/local/bin/yarn", "run", "start"] 
+


### PR DESCRIPTION
Instead of creating a new feature request I decided to implement it my own.

**What does this PR?**
Adding docker support: The sync server is run from inside a docker container having all dependencies met so it's easy to run a Brave sync server. The only thing you need is docker installed.

**Things to be done before merging**
* [ ] add some (minimal) instructions to the README.
* [ ] Configure CI to autobuild a docker image?

How about publishing this image on the official [Docker Repo (Docker Hub)](https://hub.docker.com) as an official image?

What do you think about it?