### PR TITLE
FETCH_SYNC_RECORDS can limit response to 1000 records

### DIFF
--- a/client/constants/messages.js
+++ b/client/constants/messages.js
@@ -51,7 +51,7 @@ const messages = {
    * with new records, do
    * GET_EXISTING_OBJECTS -> RESOLVE_SYNC_RECORDS -> RESOLVED_SYNC_RECORDS
    */
-  FETCH_SYNC_RECORDS: _, /* @param Array.<string> categoryNames, @param {number} startAt (in seconds) */
+  FETCH_SYNC_RECORDS: _, /* @param Array.<string> categoryNames, @param {number} startAt (in seconds or milliseconds), @param {boolean=} limitResponse true to limit response to 1000 records */
   /**
    * webview -> browser
    * after sync gets records, it requests the browser's existing objects so sync

--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -150,9 +150,10 @@ RequestUtil.prototype.parseAWSResponse = function (bytes) {
  * Get S3 objects in a category.
  * @param {string} category - the category ID
  * @param {number=} startAt return objects with timestamp >= startAt (e.g. 1482435340)
+ * @param {boolean=} limitResponse Limit response to 1000 keys, which is AWS's max response for a listObjects request. By default the Sync lib will fetch all matching records, which might take a long time.
  * @returns {Promise(Array.<Object>)}
  */
-RequestUtil.prototype.list = function (category, startAt) {
+RequestUtil.prototype.list = function (category, startAt, limitResponse) {
   const prefix = `${this.apiVersion}/${this.userId}/${category}`
   let options = {
     MaxKeys: 1000,
@@ -161,7 +162,7 @@ RequestUtil.prototype.list = function (category, startAt) {
   }
   if (startAt) { options.StartAfter = `${prefix}/${startAt}` }
   return this.withRetry(() => {
-    return s3Helper.listObjects(this.s3, options)
+    return s3Helper.listObjects(this.s3, options, limitResponse)
   })
 }
 

--- a/client/sync.js
+++ b/client/sync.js
@@ -76,13 +76,13 @@ const maybeSetDeviceId = (requester) => {
  * @param {RequestUtil} requester
  */
 const startSync = (requester) => {
-  ipc.on(messages.FETCH_SYNC_RECORDS, (e, categoryNames, startAt) => {
+  ipc.on(messages.FETCH_SYNC_RECORDS, (e, categoryNames, startAt, limitResponse) => {
     logSync(`fetching ${categoryNames} records after ${startAt}`)
     categoryNames.forEach((category) => {
       if (!proto.categories[category]) {
         throw new Error(`Unsupported sync category: ${category}`)
       }
-      requester.list(proto.categories[category], startAt).then((s3Objects) => {
+      requester.list(proto.categories[category], startAt, limitResponse).then((s3Objects) => {
         const records = requester.s3ObjectsToRecords(s3Objects)
         if (records.length === 0) { return }
         logSync(`fetched ${records.length} ${category} after ${startAt}`)

--- a/client/sync.js
+++ b/client/sync.js
@@ -5,6 +5,7 @@ const RequestUtil = require('./requestUtil')
 const recordUtil = require('./recordUtil')
 const messages = require('./constants/messages')
 const proto = require('./constants/proto')
+const s3Helper = require('../lib/s3Helper')
 const serializer = require('../lib/serializer')
 
 let ipc = window.chrome.ipcRenderer
@@ -53,16 +54,11 @@ const maybeSetDeviceId = (requester) => {
     throw new Error('cannot set device ID because AWS SDK is not initialized.')
   }
   return requester.list(proto.categories.PREFERENCES)
+    .then(s3Objects => requester.s3ObjectsToRecords(s3Objects))
     .then((records) => {
       let maxId = -1
       if (records && records.length) {
-        records.forEach((bytes) => {
-          var record = {}
-          try {
-            record = requester.decrypt(bytes)
-          } catch (e) {
-            return
-          }
+        records.forEach((record) => {
           const device = record.device
           if (device && record.deviceId[0] > maxId) {
             maxId = record.deviceId[0]
@@ -86,14 +82,16 @@ const startSync = (requester) => {
       if (!proto.categories[category]) {
         throw new Error(`Unsupported sync category: ${category}`)
       }
-      requester.list(proto.categories[category], startAt).then((records) => {
+      requester.list(proto.categories[category], startAt).then((s3Objects) => {
+        const records = requester.s3ObjectsToRecords(s3Objects)
         if (records.length === 0) { return }
         logSync(`fetched ${records.length} ${category} after ${startAt}`)
         const jsRecords = records.map((record) => {
-          const decrypted = requester.decrypt(record)
-          return recordUtil.syncRecordAsJS(decrypted)
+          return recordUtil.syncRecordAsJS(record)
         })
-        ipc.send(messages.GET_EXISTING_OBJECTS, category, jsRecords)
+        const lastObject = s3Objects[s3Objects.length - 1]
+        const lastRecordTimestamp = s3Helper.parseS3Key(lastObject.Key).timestamp
+        ipc.send(messages.GET_EXISTING_OBJECTS, category, jsRecords, lastRecordTimestamp)
       })
     })
   })

--- a/lib/s3Helper.js
+++ b/lib/s3Helper.js
@@ -81,14 +81,25 @@ module.exports.parseS3Key = function (key) {
  * listObjectsV2 plus follow all cursors.
  * @param {AwsSdk.S3} s3
  * @param {Object} options
+ * @param {boolean=} limitResponse Limit response to 1000 keys, which is AWS's max response for a listObjects request. By default the Sync lib will fetch all matching records, which might take a long time.
  * @returns {Promise}
  */
-module.exports.listObjects = function (s3, options) {
+module.exports.listObjects = function (s3, options, limitResponse) {
   return new Promise((resolve, reject) => {
-    listObjectsV2Recursively(s3, options, (error, data) => {
-      if (error) { reject(error) }
-      resolve(data)
-    })
+    if (limitResponse) {
+      s3.listObjectsV2(options, (error, data) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(data.Contents)
+        }
+      })
+    } else {
+      listObjectsV2Recursively(s3, options, (error, data) => {
+        if (error) { reject(error) }
+        resolve(data)
+      })
+    }
   })
 }
 


### PR DESCRIPTION
Fix #68 

browser/lib API changes:
- FETCH_SYNC_RECORDS
  - New param: `limitResponse` (boolean). when set to true, limits response to 1000 (previously unbounded)
  - New response param: `lastRecordTimestamp` (number), the timestamp in milliseconds of the last record in a response batch. Useful as a cursor for traversing batches of 1000.
  - Changes should be non-breaking and compatible with existing browser Sync implementations.

Test plan:
1. brave/sync tests should pass
2. `yarn dist` into browser-laptop
3. browser-laptop sync tests should pass (`yarn test -- --grep='"^Syncing"'`)