### PR TITLE
Add FETCH_SYNC_DEVICES to get all device records

### DIFF
--- a/client/constants/messages.js
+++ b/client/constants/messages.js
@@ -53,6 +53,11 @@ const messages = {
    */
   FETCH_SYNC_RECORDS: _, /* @param Array.<string> categoryNames, @param {number} startAt (in seconds or milliseconds), @param {boolean=} limitResponse true to limit response to 1000 records */
   /**
+   * browser -> webview
+   * sent to fetch all sync devices. webview responds with RESOLVED_SYNC_RECORDS.
+   */
+  FETCH_SYNC_DEVICES: _,
+  /**
    * webview -> browser
    * after sync gets records, it requests the browser's existing objects so sync
    * can perform conflict resolution.

--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -169,7 +169,7 @@ RequestUtil.prototype.list = function (category, startAt, limitResponse) {
 /**
  * From an array of S3 keys, extract and decrypt records.
  * @param {Array.<Uint8Array>} s3Objects resolved result of .list()
- * @returns {Array.<Uint8Array>}
+ * @returns {Array.<Object>}
  */
 RequestUtil.prototype.s3ObjectsToRecords = function (s3Objects) {
   const crc = require('crc')
@@ -190,6 +190,7 @@ RequestUtil.prototype.s3ObjectsToRecords = function (s3Objects) {
       let decrypted = {}
       try {
         decrypted = this.decrypt(dataBytes)
+        decrypted.syncTimestamp = parsedKey.timestamp
         output.push(decrypted)
       } catch (e) {
         console.log(`Record with CRC ${crc} can't be decrypted: ${e}`)


### PR DESCRIPTION
to support #41

Browser requests FETCH_SYNC_DEVICES when toggling sync from off -> on
It's a rebranded FETCH_SYNC_RECORDS which returns device records from all time (responses go through the existing down stream, GET_EXISTING_OBJECTS etc)