### PR TITLE
Fix record merging

### DIFF
--- a/client/recordUtil.js
+++ b/client/recordUtil.js
@@ -186,24 +186,19 @@ const mergeRecord = (record1, record2) => {
  * @returns {Array}
  */
 const mergeRecords = (recordsAndObjects) => {
-  let idsAndIndices = {}
-  let outputList = []
-  for (let n = 0; n < recordsAndObjects.length; n++) {
-    const recordAndObject = recordsAndObjects[n]
+  const objectIdMap = {} // map of objectId to [record, object]
+  recordsAndObjects.forEach((recordAndObject) => {
     const record = recordAndObject[0]
     const object = recordAndObject[1]
     const id = JSON.stringify(record.objectId)
-    const previousIndex = idsAndIndices[id]
-    if (previousIndex >= 0) {
-      const previousRecord = recordsAndObjects[previousIndex][0]
-      const mergedRecord = mergeRecord(previousRecord, record)
-      outputList[previousIndex] = [mergedRecord, object]
+    if (objectIdMap[id]) {
+      const mergedRecord = mergeRecord(objectIdMap[id][0], record)
+      objectIdMap[id] = [mergedRecord, object]
     } else {
-      idsAndIndices[id] = outputList.length
-      outputList.push(recordAndObject)
+      objectIdMap[id] = recordAndObject
     }
-  }
-  return outputList
+  })
+  return Object.values(objectIdMap)
 }
 
 /**


### PR DESCRIPTION
The previous way somtimes merged a record into record with a different objectId somehow. Using Object.values guarantees that the final number of merged records will be the same as the number of unique objectIds.

Fix https://github.com/brave/browser-laptop/issues/8454, fix tests in https://github.com/brave/browser-laptop/pull/8480

Test plan:
1. Sync to the 'rummy tarp...' group sent by slack DM.
2. You should see a bookmark folder 'f1' with two bookmarks in it; previously the bookmarks would be at the top level.
3. checkout https://github.com/brave/browser-laptop/pull/8480 and run "npm run test -- --grep='^Syncing bookmarks'". the tests should pass.