### PR TITLE
Fix record resolution of Update bookmarks with site.title

### DIFF
--- a/client/recordUtil.js
+++ b/client/recordUtil.js
@@ -43,10 +43,13 @@ const createSitePropsFromUpdateSite = (site) => {
 const createFromUpdateBookmark = CreateFromUpdate(
   'bookmark',
   (record) => {
-    return (record.bookmark.site && (
-      record.bookmark.site.location ||
-      (record.bookmark.site.customTitle && record.bookmark.isFolder)
-    ))
+    const site = record.bookmark.site
+    if (!site) { return false }
+    if (record.bookmark.isFolder) {
+      return site.customTitle || site.title
+    } else {
+      return site.location
+    }
   },
   (bookmark) => {
     if (bookmark.isFolder) {

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -244,7 +244,7 @@ test('recordUtil.resolve', (t) => {
   })
 
   t.test('UPDATE, no existing object', (t) => {
-    t.plan(7)
+    t.plan(8)
     const time = 1480000000 * 1000
     const url = 'https://jisho.org'
 
@@ -331,17 +331,24 @@ test('recordUtil.resolve', (t) => {
 
     t.test(`${t.name}, bookmark, .isFolder .site.customTitle -> create folder`, (t) => {
       const recordProps = {
-        objectData: 'bookmark',
-        bookmark: {isFolder: true, site: {customTitle: 'sweet title'}}
-      }
-      const resolvedProps = {
         bookmark: {
           site: {customTitle: 'sweet title'},
           isFolder: true
         },
         objectData: 'bookmark'
       }
-      resolveToCreate(t, recordProps, resolvedProps, t.name)
+      resolveToCreate(t, recordProps, recordProps, t.name)
+    })
+
+    t.test(`${t.name}, bookmark, .isFolder, .site.title -> create folder`, (t) => {
+      const recordProps = {
+        bookmark: {
+          site: {title: 'salty title'},
+          isFolder: true
+        },
+        objectData: 'bookmark'
+      }
+      resolveToCreate(t, recordProps, recordProps, t.name)
     })
 
     t.test(`${t.name}, siteSetting, .safeBrowsing -> null`, (t) => {


### PR DESCRIPTION
Fix #130 

Test plan:
1. `yarn dist` into browser-laptop
2. change browser laptop appConfig to sync prod and join the sync profile from https://github.com/brave/sync/issues/130 on sync prod:
```
sulfuric operate wilfully poltergeist
balder playmate fica milt
unsettle headstrong madwoman compensatory
winteriest botcher giddying crustiest
```

3. after bookmarks download, there should be a Folder2 which contains Folder1.