### PR TITLE
Adding Enpoint configuration

### DIFF
--- a/server/config/custom-environment-variables.json
+++ b/server/config/custom-environment-variables.json
@@ -3,6 +3,7 @@
   "awsSecretAccessKey": "AWS_SECRET_ACCESS_KEY",
   "awsRegion": "AWS_REGION",
   "awsS3Bucket": "AWS_S3_BUCKET",
+  /*"awsEndpoint": "http://127.0.0.1:9000",*/
   /*"apiVersion": "0",*/
   /*"categoryIdBookmarks": "0",*/
   /*"categoryIdHistorySites": "1",*/

--- a/server/lib/user-aws-s3-post-authenticator.js
+++ b/server/lib/user-aws-s3-post-authenticator.js
@@ -21,12 +21,16 @@ class UserAwsS3PostAuthenticator {
     const policySignature = crypto.createHmac('sha1', config.awsSecretAccessKey)
       .update(s3PostPolicy)
       .digest('base64')
-    return {
+    const returnValues = {
       AWSAccessKeyId: config.awsAccessKeyId,
       policy: s3PostPolicy,
       signature: policySignature,
       acl: 'private'
     }
+    if (config.AWSEndpoint) {
+      returnValues.endpoint = config.AWSEndpoint
+    } 
+    return returnValues
   }
 
   expirationDate () {

--- a/server/lib/user-aws-s3-post-authenticator.js
+++ b/server/lib/user-aws-s3-post-authenticator.js
@@ -28,7 +28,7 @@ class UserAwsS3PostAuthenticator {
       acl: 'private'
     }
     if (config.AWSEndpoint) {
-      returnValues.endpoint = config.AWSEndpoint
+      returnValues.endpoint = config.awsEndpoint
     } 
     return returnValues
   }


### PR DESCRIPTION
Hi,

Related issue #58 

**What is the goal of this PR ?**
Enable users to change the AWS endpoint by changing the config files for now.
It would be better to be able change that with a simple ENV variable.

**Why is this currently not complete ?**
I don't know if I have to also change the tests and modify the Readme. 
Maybe it would help to have a Contribution guide with coding syntax guides and Readme/tests updates guidelines ?
Do we also want this config option for the client-side too ? (I currently do not grasp how everything works).
