### PR TITLE
Better error messages from the credential server

### DIFF
--- a/server/lib/user-aws-credential-generator.js
+++ b/server/lib/user-aws-credential-generator.js
@@ -37,6 +37,10 @@ class UserAwsCredentialGenerator {
       this.awsSts().getFederationToken(params).promise()
         .catch((data) => { reject(data) })
         .then((data) => {
+          if (!data || !data.Credentials) {
+            reject(data)
+            return
+          }
           const returnData = {
             accessKeyId: data.Credentials.AccessKeyId,
             secretAccessKey: data.Credentials.SecretAccessKey,

--- a/server/users.js
+++ b/server/users.js
@@ -34,7 +34,7 @@ router.post('/:userId/credentials', (request, response) => {
       const serialized = serializer.serializer.credentialsToByteArray({aws, s3Post, bucket: BUCKET, region: REGION})
       response.send(serialized)
     })
-    .catch((error) => { response.send(error) })
+    .catch((error) => { response.status(401).send(error) })
 })
 
 // Put s3 bucket notification configuration.


### PR DESCRIPTION
The credential server returns 200 no matter what, so errors due to
invalid credentials will propagate until protobufjs thorws an error.

This changes it to return 401 whenever credentials cannot be generated.

Test plan:
1. npm start
2. npm run browsertest (which is currently failing)
3. in the error messages, you should see '401 unauthorized' instead of
   a protobuf error.