### PR TITLE
Update merge to >=1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4631,9 +4631,9 @@
       }
     },
     "merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.0.0.tgz",
-      "integrity": "sha1-tEOrRtg3xJHmIiBWqw95M+yzVo8=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {


### PR DESCRIPTION
Generate package-lock.json by
1. modifying package.json in browser-launcher to have merge dep `^1.2.1`
2. delete merge folder in node_modules
3. npm install
4. make sure we have modified packge-lock.json
5. remove entire node_modules
6. do npm install and make sure we install merge version >= 1.2.1
7. npm audit should have no errors now


fix https://github.com/brave/sync/issues/232