### PR TITLE
fix deps vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -720,6 +720,12 @@
           "bundled": true,
           "dev": true
         },
+        "merge": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+          "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+          "dev": true
+        },
         "minimist": {
           "version": "0.0.5",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
@@ -4595,12 +4601,6 @@
           }
         }
       }
-    },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",


### PR DESCRIPTION
security audit fails build for brave-core@0.59.x and blocks devops due to bad deps. see https://bravesoftware.slack.com/archives/CA5FPHWLF/p1544434896204800 for more info.

test plan:

`npm run audit` should pass