### PR TITLE
lock `merge`@1.2.1 pkg in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -708,7 +708,7 @@
       "dev": true,
       "requires": {
         "headless": "~0.1.3",
-        "merge": "~1.0.0",
+        "merge": "1.2.1",
         "minimist": "0.0.5",
         "mkdirp": "~0.3.3",
         "plist": "0.2.1",


### PR DESCRIPTION
this is a temp fix while https://github.com/substack/browser-launcher/pull/43 isn't merged