### PR TITLE
fix sorting

### DIFF
--- a/lib/s3Helper.js
+++ b/lib/s3Helper.js
@@ -82,8 +82,8 @@ module.exports.parseS3Key = function (key) {
 }
 
 function compareS3Key (a, b) {
-  const recordPartIndexA = a.Key.substring(47).split('/')[2]
-  const recordPartIndexB = b.Key.substring(47).split('/')[2]
+  const recordPartIndexA = a.Key.substring(47).split('/')[1]
+  const recordPartIndexB = b.Key.substring(47).split('/')[1]
   if (recordPartIndexA < recordPartIndexB) {
     return -1
   } else if (recordPartIndexA > recordPartIndexB) {


### PR DESCRIPTION
Sorting of records by timestamp was broken.

This PR particularly addresses https://github.com/brave/brave-browser/issues/3515 , it does not prevent re-appearing of records, but now as records will be provided sorted, then old parasite records will be neutralized by the new record.
In other words <...,CREATE, CREATE,...> or <...,DELETE, DELETE,...> or <...,UPDATE, UPDATE,...> safe. The only potential possibility of error is to have parasite records later than in the next request.
