### PR TITLE
Check text on bad request status

### DIFF
--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -81,10 +81,18 @@ RequestUtil.prototype.refreshAWSCredentials = function () {
   }
   return window.fetch(url, params)
     .then((response) => {
-      if (!response.ok) {
+      if (response.ok) {
+        return response.arrayBuffer()
+      }
+      if (response.status === 400) {
+        // Bad request
+        return response.text().then((text) => {
+          // See server/lib/request-verifier.js for error strings
+          throw new Error(`Credential server response 400. ${text}`)
+        })
+      } else {
         throw new Error(`Credential server response ${response.status}`)
       }
-      return response.arrayBuffer()
     })
     .then((buffer) => {
       console.log('Refreshed credentials.')


### PR DESCRIPTION
When the time or/and time zone on the client device is not correct, sync auth server rejects authentication with error 400/'Signed request body of the client timestamp is required.'. The clients can see only `Credential server response 400` . For the case when it is caused by time issue, this is passed to the client.
Fixes: https://github.com/brave/sync/issues/157 . 
Probably addresses:
https://github.com/brave/sync/issues/114
https://github.com/brave/sync/issues/212
https://github.com/brave/browser-android-tabs/issues/788

