### PR TITLE
Ignore records from SQS which where seen in S3

### DIFF
--- a/lib/s3Helper.js
+++ b/lib/s3Helper.js
@@ -82,8 +82,8 @@ module.exports.parseS3Key = function (key) {
 }
 
 function compareS3Key (a, b) {
-  const recordPartIndexA = a.Key.substring(47).split('/')[1]
-  const recordPartIndexB = b.Key.substring(47).split('/')[1]
+  const recordPartIndexA = module.exports.parseS3Key(a.Key).timestamp
+  const recordPartIndexB = module.exports.parseS3Key(b.Key).timestamp
   if (recordPartIndexA < recordPartIndexB) {
     return -1
   } else if (recordPartIndexA > recordPartIndexB) {
@@ -92,6 +92,13 @@ function compareS3Key (a, b) {
     return 0
   }
 }
+
+module.exports.extractPseudoKey = function (a) {
+  const parsedKey = module.exports.parseS3Key(a.Key)
+  return parsedKey.timestamp + '-' + parsedKey.recordCrc
+}
+
+var alreadySeenFromS3 = new Set()
 
 /**
  * list SQS notifications.
@@ -166,7 +173,10 @@ function listNotificationsRecursively (SQS, options, category, prefix, currentCo
           let contentMessage = {
             Key: key
           }
-          currentContent.push(contentMessage)
+          var pseudoKey = extractPseudoKey(contentMessage)
+          if (!alreadySeenFromS3.has(pseudoKey)) {
+            currentContent.push(contentMessage)
+          }
         }
         let entryToDelete = {
           Id: `${currentEntriesToDelete.length}`,
@@ -219,6 +229,12 @@ module.exports.listObjects = function (s3, options, limitResponse) {
         if (error) {
           reject(error)
         } else {
+          if (data.Contents) {
+            for (let content of data.Contents) {
+              var pseudoKey = extractPseudoKey(content)
+              alreadySeenFromS3.add(pseudoKey)
+            }
+          }
           resolve({
             contents: data.Contents,
             isTruncated: data.IsTruncated,
@@ -229,6 +245,12 @@ module.exports.listObjects = function (s3, options, limitResponse) {
     } else {
       listObjectsV2Recursively(s3, options, (error, data) => {
         if (error) { reject(error) }
+        if (data) {
+          for (let content of data) {
+            var pseudoKey = extractPseudoKey(content)
+            alreadySeenFromS3.add(pseudoKey)
+          }
+        }
         resolve({
           contents: data,
           isTruncated: false,

--- a/lib/s3Helper.js
+++ b/lib/s3Helper.js
@@ -173,7 +173,7 @@ function listNotificationsRecursively (SQS, options, category, prefix, currentCo
           let contentMessage = {
             Key: key
           }
-          var pseudoKey = extractPseudoKey(contentMessage)
+          var pseudoKey = module.exports.extractPseudoKey(contentMessage)
           if (!alreadySeenFromS3.has(pseudoKey)) {
             currentContent.push(contentMessage)
           }
@@ -231,7 +231,7 @@ module.exports.listObjects = function (s3, options, limitResponse) {
         } else {
           if (data.Contents) {
             for (let content of data.Contents) {
-              var pseudoKey = extractPseudoKey(content)
+              var pseudoKey = module.exports.extractPseudoKey(content)
               alreadySeenFromS3.add(pseudoKey)
             }
           }
@@ -247,7 +247,7 @@ module.exports.listObjects = function (s3, options, limitResponse) {
         if (error) { reject(error) }
         if (data) {
           for (let content of data) {
-            var pseudoKey = extractPseudoKey(content)
+            var pseudoKey = module.exports.extractPseudoKey(content)
             alreadySeenFromS3.add(pseudoKey)
           }
         }


### PR DESCRIPTION
There is a situation when sync lib sends duplicating records, first from S3 and then from SQS, it may happens if syncing bookmarks early after establishing a sync chain:
```
[26515:26515:0426/170809.283612:INFO:CONSOLE(5175)] "listObjects (1) S3 content.timestamp=1556287688729", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (5175)
[26515:26515:0426/170809.286318:INFO:CONSOLE(5175)] "listObjects (1) S3 content.timestamp=1556287688737", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (5175)

[26515:26515:0426/170908.000107:INFO:CONSOLE(5116)] "SQS record timestamp=1556287706300", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (5116)
[26515:26515:0426/170908.288370:INFO:CONSOLE(5116)] "SQS record timestamp=1556287688729", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (5116)
[26515:26515:0426/170908.588513:INFO:CONSOLE(5116)] "SQS record timestamp=1556287688737", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (5116)
```
This breaks merging.
On brave-browser this was workarounded with https://github.com/brave/brave-core/pull/2016 (Don't send bookmarks) , but this seems not enough.

This PR does ignores records from SQS which were seen as from S3 by unique timestampt. If these records are processed twice in between "legal" records, this may cause mess.

STR for issue using brave-syncer branch:
1. device a create `folder A` and `bookmark sync`
2. device b connect to it and move sync under A
3. device a resolves records to 0, no changes reflected


