### PR TITLE
Revert PR#313 (Merge by id and action)

### DIFF
--- a/client/recordUtil.js
+++ b/client/recordUtil.js
@@ -250,49 +250,25 @@ const mergeRecord = (record1, record2) => {
 
 /**
  * Within an array of [record, object], merge items whose records have the
- * same objectId and same actions.
- * Requirements:
- * 1) should not combine CREATE when object is not null:
- *    [[CREATE, object], [UPDATE, object]] => [[CREATE, object], [UPDATE, object]]
- *    [[CREATE, null], [UPDATE, null]] => [[CREATE(2), null]]
- *    [[CREATE, null], [UPDATE, object]] => ??? seems impossible => [[CREATE(2), object]]
- * 2) should not combine any DELETE
- * 3) all of UPDATE should be combined to single update
+ * same objectId.
  * @param {Array} recordsAndObjects Same format as input to resolveRecords().
  * @returns {Array}
  */
 const mergeRecords = (recordsAndObjects) => {
-  var mergedResult = []
+  const objectIdMap = {} // map of objectId to [record, object]
   recordsAndObjects.forEach((recordAndObject) => {
     const record = recordAndObject[0]
-    const existingObject = recordAndObject[1]
+    const object = recordAndObject[1]
     const id = JSON.stringify(record.objectId)
-
-    if (!mergedResult.length ||
-        (record.action === proto.actions.CREATE && existingObject) ||
-        record.action === proto.actions.DELETE) {
-      mergedResult.push(recordAndObject)
-      return
+    if (objectIdMap[id]) {
+      const mergedRecord = mergeRecord(objectIdMap[id][0], record)
+      objectIdMap[id] = [mergedRecord, object]
+    } else {
+      objectIdMap[id] = recordAndObject
     }
-
-    // We reach this point in 2 cases
-    // 1. record.action is UPDATE  => should merge with UPDATE or [CREATE, null]
-    // 2. record.action is CREATE and existingObject is null => should merge with UPDATE or [CREATE, null]
-
-    // Go through mergedResult from last to first
-    for (var j = mergedResult.length - 1; j >= 0; --j) {
-      if (JSON.stringify(mergedResult[j][0].objectId) === id &&
-          // Should not merge with CREATE or DELETE, only UPDATE
-          (mergedResult[j][0].action === proto.actions.UPDATE ||
-          (mergedResult[j][0].action === proto.actions.CREATE && !mergedResult[j][1]))) {
-        mergedResult[j][0] = mergeRecord(mergedResult[j][0], record)
-        return
-      }
-    }
-    mergedResult.push(recordAndObject)
-  }) // recordsAndObjects.forEach
-
-  return mergedResult
+  })
+  // webkit does not support Object.values
+  return Object.keys(objectIdMap).map((key) => objectIdMap[key])
 }
 
 /**

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -377,7 +377,7 @@ test('recordUtil.resolve', (t) => {
 })
 
 test('recordUtil.resolveRecords()', (t) => {
-  t.plan(5)
+  t.plan(6)
 
   t.test(`${t.name} resolves same data cross-platform on laptop and android`, (t) => {
     t.plan(1)
@@ -440,6 +440,28 @@ test('recordUtil.resolveRecords()', (t) => {
     const input = [[recordBookmark, null], [updateBookmark, null]]
     const resolved = recordUtil.resolveRecords(input)
     t.deepEquals(resolved, [expectedRecord], t.name)
+  })
+
+  t.test(`${t.name} Create + Delete of non-existing object should be resolve to none`, (t) => {
+    t.plan(1)
+    var createBookmark = CreateRecord({
+      objectId: recordBookmark.objectId,
+      objectData: 'bookmark',
+      bookmark: Object.assign(
+        {},
+        props.bookmark,
+        { site: Object.assign({}, siteProps) }
+      )
+    })
+    var deleteBookmark = DeleteRecord({
+      objectId: recordBookmark.objectId,
+      objectData: 'bookmark',
+      bookmark: { site: siteProps }
+    })
+    const input = [[createBookmark, null], [deleteBookmark, null]]
+    const resolved = recordUtil.resolveRecords(input)
+    const expected = []
+    t.deepEquals(resolved, expected, t.name)
   })
 
   t.test(`${t.name} resolves bookmark records with same parent folder`, (t) => {

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -377,7 +377,7 @@ test('recordUtil.resolve', (t) => {
 })
 
 test('recordUtil.resolveRecords()', (t) => {
-  t.plan(7)
+  t.plan(5)
 
   t.test(`${t.name} resolves same data cross-platform on laptop and android`, (t) => {
     t.plan(1)
@@ -405,7 +405,7 @@ test('recordUtil.resolveRecords()', (t) => {
     t.deepEquals(resolved, expected, t.name)
   })
 
-  t.test(`${t.name} sequential Updates should become no op if the merged result equals to existingObject`, (t) => {
+  t.test(`${t.name} sequential Updates should become no op`, (t) => {
     t.plan(1)
     const update1 = UpdateRecord({
       objectId: recordBookmark.objectId,
@@ -437,45 +437,9 @@ test('recordUtil.resolveRecords()', (t) => {
         { site: Object.assign({}, siteProps, updateSiteProps) }
       )
     })
-    var recordBookmarkCopy = recordBookmark
-    recordBookmarkCopy.action = proto.actions.CREATE
-    const input = [[recordBookmarkCopy, null], [updateBookmark, null]]
+    const input = [[recordBookmark, null], [updateBookmark, null]]
     const resolved = recordUtil.resolveRecords(input)
     t.deepEquals(resolved, [expectedRecord], t.name)
-  })
-
-  t.test(`${t.name} Create + Update + Update of an existing object should resolve to a separate Update`, (t) => {
-    t.plan(1)
-
-    var createBookmark = recordBookmark
-    createBookmark.action = proto.actions.CREATE
-    const existingObject = recordBookmark
-
-    var updateBookmark1 = updateBookmark
-    updateBookmark1.bookmark.site.title = 'Title1'
-    var updateBookmark2 = updateBookmark
-    updateBookmark2.bookmark.site.title = 'Title2'
-
-    const input = [[createBookmark, existingObject], [updateBookmark1, existingObject], [updateBookmark2, existingObject]]
-    const resolved = recordUtil.resolveRecords(input)
-    const expected = [updateBookmark2]
-    t.deepEquals(resolved, expected, t.name)
-  })
-
-  t.test(`${t.name} Update + Update of an existing object should resolve a single Update`, (t) => {
-    t.plan(1)
-
-    const existingObject = recordBookmark
-
-    var updateBookmark1 = updateBookmark
-    updateBookmark1.bookmark.site.title = 'Title1'
-    var updateBookmark2 = updateBookmark
-    updateBookmark2.bookmark.site.title = 'Title2'
-
-    const input = [[updateBookmark1, existingObject], [updateBookmark2, existingObject]]
-    const resolved = recordUtil.resolveRecords(input)
-    const expected = [updateBookmark2]
-    t.deepEquals(resolved, expected, t.name)
   })
 
   t.test(`${t.name} resolves bookmark records with same parent folder`, (t) => {


### PR DESCRIPTION
This is revert of https://github.com/brave/sync/pull/313 .

It causes problem with this STR
```(Android, Android) <=> Core
1. Create chain Android1 <=> Android2
2. Create bookmarks on Android1:
	wikipedia.com
	espn.com
	amazon.com
3. Wait untill bookmarks appear on Android2
4. Delete wikipedia.com from Android1
5. Wait untill bookmark will be deleted on Android2
6. Connect Core to chain
7.
Actual bookmarks:
	wikipedia.com
	espn.com
	amazon.com
Expected bookmarks:
	espn.com
	amazon.com
```
With these STR brave-core logs show
```
get-existing-objects:
	CREATE wikipedia.com
	CREATE espn.com
	CREATE amazon.com
	DELETE wikipedia.com
resolve: all pairs with null

[1207:1207:0530/132313.432076:INFO:CONSOLE(1)] "Ignoring DELETE of object 93,212,16,154,213,179,21,41,212,0,57,255,12,41,120,72.", source: chrome-extension://nomlkjnggnifocmealianaaiobmebgil/extension/brave-sync/bundles/bundle.js (1)

resolved-sync-records:
	CREATE wikipedia.com
	CREATE espn.com
	CREATE amazon.com
```
So it left first CREATE and second DELETE, but then ignored the second DELETE because existing_object==null 

PR is not required when there is a fix of `do not send records if there is no chain` https://github.com/brave/brave-core/pull/2010/commits/6f9684989c6540ad921947afbb31ca362f3b8028 



