### PR TITLE
Add metaInfo to record for better extensibility 

### DIFF
--- a/lib/api.proto
+++ b/lib/api.proto
@@ -54,7 +54,7 @@ message SyncRecord {
     repeated string fields = 6;
     bool hideInToolbar = 7;
     string order = 8;
-    repeated MetaInfo metaInfo= 9;
+    repeated MetaInfo metaInfo = 9;
   }
   message SiteSetting {
     string hostPattern = 1;
@@ -92,4 +92,5 @@ message SyncRecord {
     SiteSetting siteSetting = 6;
     Device device = 7;
   }
+  repeated MetaInfo metaInfo = 8;
 }

--- a/lib/api.proto.js
+++ b/lib/api.proto.js
@@ -1270,6 +1270,7 @@
              * @property {api.SyncRecord.ISite|null} [historySite] SyncRecord historySite
              * @property {api.SyncRecord.ISiteSetting|null} [siteSetting] SyncRecord siteSetting
              * @property {api.SyncRecord.IDevice|null} [device] SyncRecord device
+             * @property {Array.<api.IMetaInfo>|null} [metaInfo] SyncRecord metaInfo
              */
     
             /**
@@ -1281,6 +1282,7 @@
              * @param {api.ISyncRecord=} [properties] Properties to set
              */
             function SyncRecord(properties) {
+                this.metaInfo = [];
                 if (properties)
                     for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                         if (properties[keys[i]] != null)
@@ -1343,6 +1345,14 @@
              */
             SyncRecord.prototype.device = null;
     
+            /**
+             * SyncRecord metaInfo.
+             * @member {Array.<api.IMetaInfo>} metaInfo
+             * @memberof api.SyncRecord
+             * @instance
+             */
+            SyncRecord.prototype.metaInfo = $util.emptyArray;
+    
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
     
@@ -1395,6 +1405,9 @@
                     $root.api.SyncRecord.SiteSetting.encode(message.siteSetting, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
                 if (message.device != null && message.hasOwnProperty("device"))
                     $root.api.SyncRecord.Device.encode(message.device, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                if (message.metaInfo != null && message.metaInfo.length)
+                    for (var i = 0; i < message.metaInfo.length; ++i)
+                        $root.api.MetaInfo.encode(message.metaInfo[i], writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
                 return writer;
             };
     
@@ -1449,6 +1462,11 @@
                         break;
                     case 7:
                         message.device = $root.api.SyncRecord.Device.decode(reader, reader.uint32());
+                        break;
+                    case 8:
+                        if (!(message.metaInfo && message.metaInfo.length))
+                            message.metaInfo = [];
+                        message.metaInfo.push($root.api.MetaInfo.decode(reader, reader.uint32()));
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -1539,6 +1557,15 @@
                             return "device." + error;
                     }
                 }
+                if (message.metaInfo != null && message.hasOwnProperty("metaInfo")) {
+                    if (!Array.isArray(message.metaInfo))
+                        return "metaInfo: array expected";
+                    for (var i = 0; i < message.metaInfo.length; ++i) {
+                        var error = $root.api.MetaInfo.verify(message.metaInfo[i]);
+                        if (error)
+                            return "metaInfo." + error;
+                    }
+                }
                 return null;
             };
     
@@ -1598,6 +1625,16 @@
                         throw TypeError(".api.SyncRecord.device: object expected");
                     message.device = $root.api.SyncRecord.Device.fromObject(object.device);
                 }
+                if (object.metaInfo) {
+                    if (!Array.isArray(object.metaInfo))
+                        throw TypeError(".api.SyncRecord.metaInfo: array expected");
+                    message.metaInfo = [];
+                    for (var i = 0; i < object.metaInfo.length; ++i) {
+                        if (typeof object.metaInfo[i] !== "object")
+                            throw TypeError(".api.SyncRecord.metaInfo: object expected");
+                        message.metaInfo[i] = $root.api.MetaInfo.fromObject(object.metaInfo[i]);
+                    }
+                }
                 return message;
             };
     
@@ -1614,6 +1651,8 @@
                 if (!options)
                     options = {};
                 var object = {};
+                if (options.arrays || options.defaults)
+                    object.metaInfo = [];
                 if (options.defaults) {
                     object.action = options.enums === String ? "CREATE" : 0;
                     if (options.bytes === String)
@@ -1656,6 +1695,11 @@
                     object.device = $root.api.SyncRecord.Device.toObject(message.device, options);
                     if (options.oneofs)
                         object.objectData = "device";
+                }
+                if (message.metaInfo && message.metaInfo.length) {
+                    object.metaInfo = [];
+                    for (var j = 0; j < message.metaInfo.length; ++j)
+                        object.metaInfo[j] = $root.api.MetaInfo.toObject(message.metaInfo[j], options);
                 }
                 return object;
             };


### PR DESCRIPTION
for storing fields in SyncEntity
https://cs.chromium.org/chromium/src/components/sync/protocol/sync.proto?l=159&rcl=b00902f1cd54e58660ed1482d8cf98aba4d825d6
so it can be used by not just Bookmark but all sync types
The original metaInfo in Bookmark can be used to sync chromium bookmark node meta info