### PR TITLE
Ignore conflicted records during resolve

### DIFF
--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -377,7 +377,7 @@ test('recordUtil.resolve', (t) => {
 })
 
 test('recordUtil.resolveRecords()', (t) => {
-  t.plan(7)
+  t.plan(8)
 
   t.test(`${t.name} resolves same data cross-platform on laptop and android`, (t) => {
     t.plan(1)
@@ -464,7 +464,7 @@ test('recordUtil.resolveRecords()', (t) => {
     t.deepEquals(resolved, expected, t.name)
   })
 
-  t.test(`${t.name} Create + existing and Modify + existing: should be resolved to Modify`, (t) => {
+  t.test(`${t.name} [[CREATE, object], [UPDATE, object]] => [[UPDATE, object]]`, (t) => {
     // ... and data from Create should be dropped
     t.plan(1)
     const create = CreateRecord({
@@ -490,6 +490,40 @@ test('recordUtil.resolveRecords()', (t) => {
       [update, existingObject]
     ]
     const expected = [update]
+    const resolved = recordUtil.resolveRecords(input)
+    t.deepEquals(resolved, expected, t.name)
+  })
+
+  t.test(`${t.name} [[CREATE/UPDATE, object]..., [DELETE, object]] => [[DELETE, object]]`, (t) => {
+    t.plan(1)
+    const create = CreateRecord({
+      objectId: recordBookmark.objectId,
+      objectData: 'bookmark',
+      bookmark: Object.assign(
+        {},
+        props.bookmark,
+        { site: Object.assign({}, siteProps) }
+      )
+    })
+    const existingObject = Object.assign({}, create)
+    existingObject.action = proto.actions.UPDATE
+
+    const update = Object.assign({}, existingObject)
+    update.bookmark = Object.assign({}, existingObject.bookmark)
+    update.bookmark.site = Object.assign({}, existingObject.bookmark.site)
+    update.bookmark.site.customTitle += `-Updated`
+
+    const deleteRecord = Object.assign({}, update)
+    deleteRecord.action = proto.actions.DELETE
+    deleteRecord.bookmark = Object.assign({}, update.bookmark)
+    deleteRecord.bookmark.site = Object.assign({}, update.bookmark.site)
+
+    const input = [
+      [create, existingObject],
+      [update, existingObject],
+      [deleteRecord, existingObject]
+    ]
+    const expected = [deleteRecord]
     const resolved = recordUtil.resolveRecords(input)
     t.deepEquals(resolved, expected, t.name)
   })

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -377,7 +377,7 @@ test('recordUtil.resolve', (t) => {
 })
 
 test('recordUtil.resolveRecords()', (t) => {
-  t.plan(6)
+  t.plan(7)
 
   t.test(`${t.name} resolves same data cross-platform on laptop and android`, (t) => {
     t.plan(1)
@@ -461,6 +461,36 @@ test('recordUtil.resolveRecords()', (t) => {
     const input = [[createBookmark, null], [deleteBookmark, null]]
     const resolved = recordUtil.resolveRecords(input)
     const expected = []
+    t.deepEquals(resolved, expected, t.name)
+  })
+
+  t.test(`${t.name} Create + existing and Modify + existing: should be resolved to Modify`, (t) => {
+    // ... and data from Create should be dropped
+    t.plan(1)
+    const create = CreateRecord({
+      objectId: recordBookmark.objectId,
+      objectData: 'bookmark',
+      bookmark: Object.assign(
+        {},
+        props.bookmark,
+        { site: Object.assign({}, siteProps) }
+      )
+    })
+
+    const existingObject = Object.assign({}, create)
+    existingObject.action = proto.actions.UPDATE
+
+    const update = Object.assign({}, existingObject)
+    update.bookmark = Object.assign({}, existingObject.bookmark)
+    update.bookmark.site = Object.assign({}, existingObject.bookmark.site)
+    update.bookmark.site.customTitle += `-Updated`
+
+    const input = [
+      [create, existingObject],
+      [update, existingObject]
+    ]
+    const expected = [update]
+    const resolved = recordUtil.resolveRecords(input)
     t.deepEquals(resolved, expected, t.name)
   })
 


### PR DESCRIPTION
Fixes https://github.com/brave/sync/issues/261 

When sync lib gets unexpected data, during the merge it can lead to wrong resolve result calculated changes.

These are in https://github.com/brave/sync/blob/staging/client/recordUtil.js#L212 when `nullIgnore()` is returned:
1) CREATE when existing object is not null;
2) DELETE when existing object is already null;

If this records are ignored by themselves , it doesn't cause a trouble. 
But before to be ignored, such records absorb the records of the same `objectId` and then the required changes become wrongly ignored. The illustration is https://github.com/brave/sync/issues/261 .

Obviously, if we would not do resolve and apply each record to the model, this would give the result.

So to avoid the mess on resolve, such pairs which would be resolved to null, but can make other important changes to be wrongly ignored - such pairs are removed from the merge on resolve operation.

Will mark as not draft when add the test cases.