### PR TITLE
Introduce device id v2

### DIFF
--- a/client/constants/messages.js
+++ b/client/constants/messages.js
@@ -34,12 +34,17 @@ const messages = {
    * saved. 'config' contains apiVersion, serverUrl, debug;
    * see server/config/default.json
    */
-  GOT_INIT_DATA: _, /* @param {Array} seed, @param {Array} deviceId, @param {Object} config */
+  GOT_INIT_DATA: _, /* @param {Array} seed, @param {Array} deviceId,
+                     * @param {Object} config, @param {string} deviceIdV2
+                     * */
   /**
    * webview -> browser
    * browser must save values in persistent storage if non-empty
+   * It will be called during initial setup or deviceIdV2 migration
    */
-  SAVE_INIT_DATA: _, /* @param {Uint8Array} seed, @param {Uint8Array} deviceId */
+  SAVE_INIT_DATA: _, /* @param {Uint8Array} seed, @param {Uint8Array} deviceId,
+                      * @param {string} deviceIdV2
+                      */
   /**
    * webview -> browser
    * sent when sync has finished initialization

--- a/client/init.js
+++ b/client/init.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const crypto = require('brave-crypto')
+const libCrypto = require('../lib/crypto')
 const messages = require('./constants/messages')
 const {syncVersion} = require('./config')
-const uuidv4 = require('uuid/v4')
 
 /**
  * Initializes crypto and device ID
@@ -13,14 +13,16 @@ module.exports.init = function () {
   return new Promise((resolve, reject) => {
     const ipc = window.chrome.ipcRenderer
     ipc.send(messages.GET_INIT_DATA, syncVersion)
-    ipc.once(messages.GOT_INIT_DATA, (e, seed, deviceId, config, deviceUuid) => {
+    ipc.once(messages.GOT_INIT_DATA, (e, seed, deviceId, config, deviceIdV2) => {
+      // TODO(darkdh): save uuid for migrated devices
+      if (deviceIdV2.length === 0) {
+        deviceIdV2 = Buffer.from(libCrypto.randomBytes(3)).toString('hex')
+      }
       if (seed === null) {
         // Generate a new "persona"
         seed = crypto.getSeed() // 32 bytes
         deviceId = new Uint8Array([0])
-        // dash is reserved for s3 key delimiters
-        deviceUuid = uuidv4().replace(/(-)/g, '_')
-        ipc.send(messages.SAVE_INIT_DATA, seed, deviceId, deviceUuid)
+        ipc.send(messages.SAVE_INIT_DATA, seed, deviceId, deviceIdV2)
         // TODO: The background process should listen for SAVE_INIT_DATA and emit
         // GOT_INIT_DATA once the save is successful
       }
@@ -31,7 +33,7 @@ module.exports.init = function () {
         reject(new Error('Invalid crypto seed'))
         return
       }
-      resolve({seed, deviceId, config, deviceUuid})
+      resolve({seed, deviceId, config, deviceIdV2})
     })
   })
 }

--- a/client/init.js
+++ b/client/init.js
@@ -3,6 +3,7 @@
 const crypto = require('brave-crypto')
 const messages = require('./constants/messages')
 const {syncVersion} = require('./config')
+const uuidv4 = require('uuid/v4')
 
 /**
  * Initializes crypto and device ID
@@ -12,12 +13,14 @@ module.exports.init = function () {
   return new Promise((resolve, reject) => {
     const ipc = window.chrome.ipcRenderer
     ipc.send(messages.GET_INIT_DATA, syncVersion)
-    ipc.once(messages.GOT_INIT_DATA, (e, seed, deviceId, config) => {
+    ipc.once(messages.GOT_INIT_DATA, (e, seed, deviceId, config, deviceUuid) => {
       if (seed === null) {
         // Generate a new "persona"
         seed = crypto.getSeed() // 32 bytes
         deviceId = new Uint8Array([0])
-        ipc.send(messages.SAVE_INIT_DATA, seed, deviceId)
+        // dash is reserved for s3 key delimiters
+        deviceUuid = uuidv4().replace(/(-)/g, '_')
+        ipc.send(messages.SAVE_INIT_DATA, seed, deviceId, deviceUuid)
         // TODO: The background process should listen for SAVE_INIT_DATA and emit
         // GOT_INIT_DATA once the save is successful
       }
@@ -28,7 +31,7 @@ module.exports.init = function () {
         reject(new Error('Invalid crypto seed'))
         return
       }
-      resolve({seed, deviceId, config})
+      resolve({seed, deviceId, config, deviceUuid})
     })
   })
 }

--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -342,9 +342,10 @@ RequestUtil.prototype.sqsName = function (deviceId, category) {
 /**
  * Creates SQS for the current device.
  * @param {string} deviceId
+ * @param {string} deviceUuid
  * @returns {Promise}
  */
-RequestUtil.prototype.createAndSubscribeSQS = function (deviceId) {
+RequestUtil.prototype.createAndSubscribeSQS = function (deviceId, deviceUuid) {
   // Creating a query for the current userId
   if (!deviceId) {
     throw new Error('createSQS failed. deviceId is null!')

--- a/client/requestUtil.js
+++ b/client/requestUtil.js
@@ -420,8 +420,7 @@ RequestUtil.prototype.createAndSubscribeSQS = function (deviceId, deviceIdV2) {
   var createSQSPromises = []
   // Simple for loop instead foreach to capture 'this'
   for (var i = 0; i < CATEGORIES_FOR_SQS.length; ++i) {
-    // Doesn't have to create about to deprecate quques
-    // createSQSPromises.push(createAndSubscribeSQSforCategory(deviceId, CATEGORIES_FOR_SQS[i], this))
+    // Doesn't have to create about to deprecated queues
     createSQSPromises.push(subscribeOldSQSforCategory(deviceId, CATEGORIES_FOR_SQS[i], this))
     createSQSPromises.push(createAndSubscribeSQSforCategory(deviceIdV2, CATEGORIES_FOR_SQS[i], this))
     // TODO(darkdh): encode into base64

--- a/client/sync.js
+++ b/client/sync.js
@@ -7,7 +7,7 @@ const recordUtil = require('./recordUtil')
 const messages = require('./constants/messages')
 const proto = require('./constants/proto')
 const serializer = require('../lib/serializer')
-const {deriveKeys} = require('../lib/crypto')
+const {deriveKeys, generateDeviceIdV2} = require('../lib/crypto')
 
 let ipc = window.chrome.ipcRenderer
 
@@ -52,7 +52,7 @@ const logSync = (message, logLevel = DEBUG) => {
  * @returns {Promise}
  */
 const maybeSetDeviceId = (requester) => {
-  if (clientDeviceId !== null) {
+  if (clientDeviceId !== null && clientDeviceIdV2.length !== 0 ) {
     return Promise.resolve(requester)
   }
   if (!requester || !requester.s3) {
@@ -72,6 +72,7 @@ const maybeSetDeviceId = (requester) => {
         })
       }
       clientDeviceId = new Uint8Array([maxId + 1])
+      clientDeviceIdV2 = generateDeviceIdV2()
       ipc.send(messages.SAVE_INIT_DATA, seed, clientDeviceId, clientDeviceIdV2)
       return Promise.resolve(requester)
     })

--- a/client/sync.js
+++ b/client/sync.js
@@ -8,7 +8,6 @@ const messages = require('./constants/messages')
 const proto = require('./constants/proto')
 const serializer = require('../lib/serializer')
 const {deriveKeys} = require('../lib/crypto')
-const uuidv4 = require('uuid/v4')
 
 let ipc = window.chrome.ipcRenderer
 
@@ -19,7 +18,7 @@ const ERROR = 2
 const logElement = document.querySelector('#output')
 
 var clientDeviceId = null
-var clientDeviceUuid = null
+var clientDeviceIdV2 = null
 var clientUserId = null
 var clientKeys = {}
 var config = {}
@@ -73,9 +72,7 @@ const maybeSetDeviceId = (requester) => {
         })
       }
       clientDeviceId = new Uint8Array([maxId + 1])
-      // dash is reserved for s3 key delimiters
-      clientDeviceUuid = uuidv4().replace(/(-)/g, '_')
-      ipc.send(messages.SAVE_INIT_DATA, seed, clientDeviceId, clientDeviceUuid)
+      ipc.send(messages.SAVE_INIT_DATA, seed, clientDeviceId, clientDeviceIdV2)
       return Promise.resolve(requester)
     })
 }
@@ -256,8 +253,7 @@ const main = () => {
     const clientSerializer = values[0]
     const keys = deriveKeys(values[1].seed)
     const deviceId = values[1].deviceId
-    const deviceUuid = values[1].deviceUuid
-    logSync(`deviceUUID ${deviceUuid}`)
+    clientDeviceIdV2 = values[1].deviceIdV2
     seed = values[1].seed
     clientKeys = keys
     config = values[1].config
@@ -294,8 +290,8 @@ const main = () => {
     })
     .then((requester) => {
       if (clientDeviceId !== null && requester && requester.s3) {
-        logSync('set device ID: ' + clientDeviceId + ' device UUID: ' + clientDeviceUuid)
-        requester.createAndSubscribeSQS(clientDeviceId, clientDeviceUuid).then(() => {
+        logSync('set device ID: ' + clientDeviceId + ' device ID V2: ' + clientDeviceIdV2)
+        requester.createAndSubscribeSQS(clientDeviceId, clientDeviceIdV2).then(() => {
           startSync(requester)
         })
           .catch((e) => {

--- a/client/sync.js
+++ b/client/sync.js
@@ -52,7 +52,11 @@ const logSync = (message, logLevel = DEBUG) => {
  * @returns {Promise}
  */
 const maybeSetDeviceId = (requester) => {
-  if (clientDeviceId !== null && clientDeviceIdV2.length !== 0 ) {
+  if (clientDeviceId !== null) {
+    if (clientDeviceIdV2.length === 0) {
+      clientDeviceIdV2 = generateDeviceIdV2()
+      ipc.send(messages.SAVE_INIT_DATA, seed, clientDeviceId, clientDeviceIdV2)
+    }
     return Promise.resolve(requester)
   }
   if (!requester || !requester.s3) {

--- a/lib/api.proto
+++ b/lib/api.proto
@@ -82,7 +82,7 @@ message SyncRecord {
   }
   message Device {
     string name = 1;
-    string uuid = 2;
+    string deviceIdV2 = 2;
   }
   Action action = 1;
   bytes deviceId = 2;

--- a/lib/api.proto
+++ b/lib/api.proto
@@ -82,6 +82,7 @@ message SyncRecord {
   }
   message Device {
     string name = 1;
+    string uuid = 2;
   }
   Action action = 1;
   bytes deviceId = 2;

--- a/lib/api.proto.js
+++ b/lib/api.proto.js
@@ -2970,7 +2970,7 @@
                  * @memberof api.SyncRecord
                  * @interface IDevice
                  * @property {string|null} [name] Device name
-                 * @property {string|null} [uuid] Device uuid
+                 * @property {string|null} [deviceIdV2] Device deviceIdV2
                  */
     
                 /**
@@ -2997,12 +2997,12 @@
                 Device.prototype.name = "";
     
                 /**
-                 * Device uuid.
-                 * @member {string} uuid
+                 * Device deviceIdV2.
+                 * @member {string} deviceIdV2
                  * @memberof api.SyncRecord.Device
                  * @instance
                  */
-                Device.prototype.uuid = "";
+                Device.prototype.deviceIdV2 = "";
     
                 /**
                  * Creates a new Device instance using the specified properties.
@@ -3030,8 +3030,8 @@
                         writer = $Writer.create();
                     if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-                    if (message.uuid != null && message.hasOwnProperty("uuid"))
-                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.uuid);
+                    if (message.deviceIdV2 != null && message.hasOwnProperty("deviceIdV2"))
+                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.deviceIdV2);
                     return writer;
                 };
     
@@ -3070,7 +3070,7 @@
                             message.name = reader.string();
                             break;
                         case 2:
-                            message.uuid = reader.string();
+                            message.deviceIdV2 = reader.string();
                             break;
                         default:
                             reader.skipType(tag & 7);
@@ -3110,9 +3110,9 @@
                     if (message.name != null && message.hasOwnProperty("name"))
                         if (!$util.isString(message.name))
                             return "name: string expected";
-                    if (message.uuid != null && message.hasOwnProperty("uuid"))
-                        if (!$util.isString(message.uuid))
-                            return "uuid: string expected";
+                    if (message.deviceIdV2 != null && message.hasOwnProperty("deviceIdV2"))
+                        if (!$util.isString(message.deviceIdV2))
+                            return "deviceIdV2: string expected";
                     return null;
                 };
     
@@ -3130,8 +3130,8 @@
                     var message = new $root.api.SyncRecord.Device();
                     if (object.name != null)
                         message.name = String(object.name);
-                    if (object.uuid != null)
-                        message.uuid = String(object.uuid);
+                    if (object.deviceIdV2 != null)
+                        message.deviceIdV2 = String(object.deviceIdV2);
                     return message;
                 };
     
@@ -3150,12 +3150,12 @@
                     var object = {};
                     if (options.defaults) {
                         object.name = "";
-                        object.uuid = "";
+                        object.deviceIdV2 = "";
                     }
                     if (message.name != null && message.hasOwnProperty("name"))
                         object.name = message.name;
-                    if (message.uuid != null && message.hasOwnProperty("uuid"))
-                        object.uuid = message.uuid;
+                    if (message.deviceIdV2 != null && message.hasOwnProperty("deviceIdV2"))
+                        object.deviceIdV2 = message.deviceIdV2;
                     return object;
                 };
     

--- a/lib/api.proto.js
+++ b/lib/api.proto.js
@@ -2970,6 +2970,7 @@
                  * @memberof api.SyncRecord
                  * @interface IDevice
                  * @property {string|null} [name] Device name
+                 * @property {string|null} [uuid] Device uuid
                  */
     
                 /**
@@ -2994,6 +2995,14 @@
                  * @instance
                  */
                 Device.prototype.name = "";
+    
+                /**
+                 * Device uuid.
+                 * @member {string} uuid
+                 * @memberof api.SyncRecord.Device
+                 * @instance
+                 */
+                Device.prototype.uuid = "";
     
                 /**
                  * Creates a new Device instance using the specified properties.
@@ -3021,6 +3030,8 @@
                         writer = $Writer.create();
                     if (message.name != null && message.hasOwnProperty("name"))
                         writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                    if (message.uuid != null && message.hasOwnProperty("uuid"))
+                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.uuid);
                     return writer;
                 };
     
@@ -3057,6 +3068,9 @@
                         switch (tag >>> 3) {
                         case 1:
                             message.name = reader.string();
+                            break;
+                        case 2:
+                            message.uuid = reader.string();
                             break;
                         default:
                             reader.skipType(tag & 7);
@@ -3096,6 +3110,9 @@
                     if (message.name != null && message.hasOwnProperty("name"))
                         if (!$util.isString(message.name))
                             return "name: string expected";
+                    if (message.uuid != null && message.hasOwnProperty("uuid"))
+                        if (!$util.isString(message.uuid))
+                            return "uuid: string expected";
                     return null;
                 };
     
@@ -3113,6 +3130,8 @@
                     var message = new $root.api.SyncRecord.Device();
                     if (object.name != null)
                         message.name = String(object.name);
+                    if (object.uuid != null)
+                        message.uuid = String(object.uuid);
                     return message;
                 };
     
@@ -3129,10 +3148,14 @@
                     if (!options)
                         options = {};
                     var object = {};
-                    if (options.defaults)
+                    if (options.defaults) {
                         object.name = "";
+                        object.uuid = "";
+                    }
                     if (message.name != null && message.hasOwnProperty("name"))
                         object.name = message.name;
+                    if (message.uuid != null && message.hasOwnProperty("uuid"))
+                        object.uuid = message.uuid;
                     return object;
                 };
     

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -113,6 +113,10 @@ module.exports.decrypt = function (ciphertext/* : Uint8Array */,
   return nacl.secretbox.open(ciphertext, nonce, secretboxKey)
 }
 
-module.exports.generateDeviceIdV2 = function() {
+/**
+ * Generate device id v2 which is a 3 random bytes hex encoded string
+ * @returns {string} device id v2
+ */
+module.exports.generateDeviceIdV2 = function () {
   return Buffer.from(nacl.randomBytes(3)).toString('hex')
 }

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -112,3 +112,7 @@ module.exports.decrypt = function (ciphertext/* : Uint8Array */,
   nonce/* : Uint8Array */, secretboxKey/* : Uint8Array */) {
   return nacl.secretbox.open(ciphertext, nonce, secretboxKey)
 }
+
+module.exports.generateDeviceIdV2 = function() {
+  return Buffer.from(nacl.randomBytes(3)).toString('hex')
+}

--- a/lib/s3Helper.js
+++ b/lib/s3Helper.js
@@ -116,7 +116,8 @@ module.exports.listNotifications = function (SQS, options, category, prefix) {
     let queueAttributesParams = {
       QueueUrl: options.QueueUrl,
       AttributeNames: [
-        'ApproximateNumberOfMessages'
+        'ApproximateNumberOfMessages',
+        'CreatedTimestamp'
       ]
     }
     SQS.getQueueAttributes(queueAttributesParams, (errorAttr, dataAttr) => {
@@ -125,9 +126,11 @@ module.exports.listNotifications = function (SQS, options, category, prefix) {
         reject(errorAttr)
       } else if (dataAttr) {
         let approximateNumberOfMessages = parseInt(dataAttr.Attributes.ApproximateNumberOfMessages)
+        let createdTimeStamp = dataAttr.Attributes.CreatedTimestamp
         if (approximateNumberOfMessages === 0) {
           resolve({
-            contents: content
+            contents: content,
+            createdTimeStamp
           })
 
           return
@@ -138,7 +141,8 @@ module.exports.listNotifications = function (SQS, options, category, prefix) {
               reject(error)
             }
             resolve({
-              contents: data
+              contents: data,
+              createdTimeStamp
             })
           })
       }

--- a/test/client/deviceIdV2.js
+++ b/test/client/deviceIdV2.js
@@ -1,0 +1,148 @@
+const test = require('tape')
+const testHelper = require('../testHelper')
+const clientTestHelper = require('./testHelper')
+const Serializer = require('../../lib/serializer')
+const RequestUtil = require('../../client/requestUtil')
+const proto = require('../../client/constants/proto')
+
+test('deviceId V2 migration', (t) => {
+  t.test('constructor', (t) => {
+    Serializer.init().then((serializer) => {
+      clientTestHelper.getSerializedCredentials(serializer).then((data) => {
+        const args = {
+          apiVersion: clientTestHelper.CONFIG.apiVersion,
+          credentialsBytes: data.serializedCredentials,
+          keys: data.keys,
+          serializer,
+          serverUrl: clientTestHelper.CONFIG.serverUrl
+        }
+
+        t.throws(() => { return new RequestUtil() }, 'requires arguments')
+        const requiredArgs = ['apiVersion', 'keys', 'serializer', 'serverUrl']
+        for (let arg of requiredArgs) {
+          let lessArgs = Object.assign({}, args)
+          lessArgs[arg] = undefined
+          t.throws(() => { return new RequestUtil(lessArgs) }, `requires ${arg}`)
+        }
+
+        const requestUtil = new RequestUtil(args)
+        requestUtil.createAndSubscribeSQSForTest('1')
+          .then(() => {
+            t.pass('can instantiate requestUtil')
+            t.test('prototype', (t) => {
+              setTimeout(() => {
+                testPrototype(t, requestUtil, data.keys)
+              }, 5000)
+            })
+          }).catch((error) => { t.end(error) })
+      }).catch((error) => { t.end(error) })
+    })
+  })
+
+  const testPrototype = (t, requestUtil, keys) => {
+    test.onFinish(() => {
+      requestUtil.deleteUser()
+        .then(() => {
+          requestUtil.purgeUserQueue()
+        })
+        .catch((error) => { console.log(`Cleanup failed: ${error}`) })
+    })
+
+    const record = {
+      action: 'CREATE',
+      deviceId: new Uint8Array([0]),
+      objectId: testHelper.newUuid(),
+      bookmark: {
+        site: {
+          location: `https://brave.com?q=${'x'.repeat(4)}`,
+          title: 'Brave',
+          lastAccessedTime: 1480000000 * 1000,
+          creationTime: 1480000000 * 1000
+        },
+        isFolder: false,
+        hideInToolbar: false,
+        order: '1.0.0.1'
+      }
+    }
+    const record2 = {
+      action: 'CREATE',
+      deviceId: new Uint8Array([0]),
+      objectId: testHelper.newUuid(),
+      bookmark: {
+        site: {
+          location: `https://brave.com?q=${'y'.repeat(4)}`,
+          title: 'Brave2',
+          lastAccessedTime: 1480000000 * 1000,
+          creationTime: 1480000000 * 1000
+        },
+        isFolder: false,
+        hideInToolbar: false,
+        order: '1.0.0.2'
+      }
+    }
+    t.test('#put record before migration', (t) => {
+      requestUtil.put(proto.categories.BOOKMARKS, record)
+        .then((response) => {
+          t.pass(`${t.name} resolves`)
+          requestUtil.createAndSubscribeSQS('1', 'beef12')
+            .then(() => {
+              setTimeout(() => {
+                t.pass('subscribe to new SQS queue')
+                testCanListFromOldQueue(t)
+              }, 5000)
+            }).catch((error) => { t.end(error) })
+        })
+        .catch((error) => { t.fail(error) })
+    })
+    const testCanListFromOldQueue = (t) => {
+      t.test('can list notification from old SQS queue', (t) => {
+        let currentTime = new Date().getTime()
+        requestUtil.list(proto.categories.BOOKMARKS, currentTime)
+          .then(s3Objects => requestUtil.s3ObjectsToRecords(s3Objects.contents))
+          .then((response) => {
+            t.equals(response.length, 1)
+            const s3Record = response[0].record
+            // FIXME: Should this deserialize to 'CREATE' ?
+            t.equals(s3Record.action, 0, `${t.name}: action`)
+            t.deepEquals(s3Record.deviceId, record.deviceId, `${t.name}: deviceId`)
+            t.deepEquals(s3Record.objectId, record.objectId, `${t.name}: objectId`)
+            t.deepEquals(s3Record.bookmark.site, record.bookmark.site, `${t.name}: bookmark.site`)
+            t.deepEquals(s3Record.bookmark.isFolder, record.bookmark.isFolder, `${t.name}: bookmark.isFolder`)
+            t.deepEquals(s3Record.bookmark.hideInToolbar, record.bookmark.hideInToolbar, `${t.name}: bookmark.hideInToolbar`)
+            t.deepEquals(s3Record.bookmark.order, record.bookmark.order, `${t.name}: bookmark.order`)
+            putRecordAfterMigration(t)
+          })
+          .catch((error) => { t.fail(error) })
+      })
+    }
+    const putRecordAfterMigration = (t) => {
+      requestUtil.put(proto.categories.BOOKMARKS, record2)
+        .then((response) => {
+          setTimeout(() => {
+            testCanListFromBothQueues(t)
+          }, 5000)
+        })
+        .catch((error) => { t.fail(error) })
+    }
+    const testCanListFromBothQueues = (t) => {
+      t.test('can list notifications from new and old SQS queues', (t) => {
+        let currentTime = new Date().getTime()
+        requestUtil.list(proto.categories.BOOKMARKS, currentTime)
+          .then(s3Objects => requestUtil.s3ObjectsToRecords(s3Objects.contents))
+          .then((response) => {
+            t.equals(response.length, 1)
+            const s3Record = response[0].record
+            // FIXME: Should this deserialize to 'CREATE' ?
+            t.equals(s3Record.action, 0, `${t.name}: action`)
+            t.deepEquals(s3Record.deviceId, record2.deviceId, `${t.name}: deviceId`)
+            t.deepEquals(s3Record.objectId, record2.objectId, `${t.name}: objectId`)
+            t.deepEquals(s3Record.bookmark.site, record2.bookmark.site, `${t.name}: bookmark.site`)
+            t.deepEquals(s3Record.bookmark.isFolder, record2.bookmark.isFolder, `${t.name}: bookmark.isFolder`)
+            t.deepEquals(s3Record.bookmark.hideInToolbar, record2.bookmark.hideInToolbar, `${t.name}: bookmark.hideInToolbar`)
+            t.deepEquals(s3Record.bookmark.order, record2.bookmark.order, `${t.name}: bookmark.order`)
+            t.end()
+          })
+      })
+    }
+  }
+})

--- a/test/client/recordUtil.js
+++ b/test/client/recordUtil.js
@@ -2,6 +2,7 @@ const test = require('tape')
 const testHelper = require('../testHelper')
 const timekeeper = require('timekeeper')
 const proto = require('../../client/constants/proto')
+const {generateDeviceIdV2} = require('../../lib/crypto')
 const recordUtil = require('../../client/recordUtil')
 const Serializer = require('../../lib/serializer')
 
@@ -548,8 +549,10 @@ test('recordUtil.syncRecordAsJS()', (t) => {
     })
     conversionEquals({ objectData: 'siteSetting', siteSetting })
 
+    const deviceIdV2 = generateDeviceIdV2()
     const device = serializer.api.SyncRecord.Device.create({
-      name: 'mobile pyramid'
+      name: 'mobile pyramid',
+      deviceIdV2
     })
     conversionEquals({ objectData: 'device', device })
   })

--- a/test/client/requestUtil.js
+++ b/test/client/requestUtil.js
@@ -2,6 +2,7 @@ const test = require('tape')
 const testHelper = require('../testHelper')
 const timekeeper = require('timekeeper')
 const clientTestHelper = require('./testHelper')
+const {generateDeviceIdV2} = require('../../lib/crypto')
 const Serializer = require('../../lib/serializer')
 const RequestUtil = require('../../client/requestUtil')
 const proto = require('../../client/constants/proto')
@@ -30,7 +31,7 @@ test('client RequestUtil', (t) => {
         }
 
         const requestUtil = new RequestUtil(args)
-        requestUtil.createAndSubscribeSQS('0')
+        requestUtil.createAndSubscribeSQS('0', generateDeviceIdV2())
           .then(()=> {
             t.pass('can instantiate requestUtil')
             t.test('prototype', (t) => {


### PR DESCRIPTION
fix https://github.com/brave/sync/issues/333

This PR introduce device id v2 which is a 3 random bytes hex encoded string.
We also keep device id for backward compatibility.
Migration from existing device would be:
1. There will be extra `SAVE_INIT_DATA` for updating device id v2
2. Create new SQS queues using device id v2 and subscribe to old SQS queues created by device id
3. We will fetch from both queues for 24 hours and then delete the old queues