### PR TITLE
Revert resolutions file entry fix for minimist (master)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
           "dev": true
         },
         "mkdirp": {
@@ -1351,14 +1351,6 @@
         "minimist": "^1.2.0",
         "mkdirp": "~0.5.1",
         "rimraf": "^2.5.4"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "crc": {
@@ -1688,14 +1680,6 @@
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "dezalgo": {
@@ -1797,12 +1781,6 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
           "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
           "dev": true
-        },
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
         }
       }
     },
@@ -1847,12 +1825,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
         },
         "ms": {
           "version": "2.1.1",
@@ -3021,9 +2993,11 @@
           }
         },
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+          "version": "0.0.8",
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
@@ -3054,15 +3028,6 @@
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-              "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "ms": {
@@ -3222,9 +3187,9 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-              "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+              "version": "1.2.0",
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -3655,9 +3620,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "readable-stream": {
@@ -3732,9 +3697,9 @@
           "dev": true
         },
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "object-keys": {
@@ -4284,12 +4249,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "json-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
-      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww=",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4332,13 +4291,6 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
-        }
       }
     },
     "jsonfile": {
@@ -4618,12 +4570,6 @@
             "strip-bom": "^2.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -4768,6 +4714,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -4799,9 +4750,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
@@ -4966,34 +4917,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "npm-force-resolutions": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.3.tgz",
-      "integrity": "sha512-xbIPAGzD3nrJHDLtnRFt/O83teTA8ju5pWTf8W6OKL4D0XD9EjdRNJhzg4bSXWuucE+l1HGdTpOJR/l1Mi1Ycg==",
-      "dev": true,
-      "requires": {
-        "json-format": "^1.0.1",
-        "source-map-support": "^0.5.5"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -5016,14 +4939,6 @@
         "request": "^2.45.0",
         "single-line-log": "^1.1.2",
         "throttleit": "0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "number-is-nan": {
@@ -5365,9 +5280,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "wordwrap": {
@@ -6054,14 +5969,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "react-is": {
@@ -6882,14 +6789,6 @@
         "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
         "pkg-conf": "^3.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "static-extend": {
@@ -7071,14 +6970,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.1.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "sumchecker": {
@@ -7185,14 +7076,6 @@
         "resumer": "~0.0.0",
         "string.prototype.trim": "~1.1.2",
         "through": "~2.3.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-          "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
-          "dev": true
-        }
       }
     },
     "tape-run": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Brave sync server and client",
   "main": "server/index.js",
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
     "lint": "standard",
     "lint-fix": "standard --fix",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
@@ -45,7 +44,6 @@
     "cpr": "^3.0.1",
     "flow-bin": "^0.35.0",
     "nodemon": "^1.18.6",
-    "npm-force-resolutions": "0.0.3",
     "optional-dev-dependency": "^2.0.1",
     "standard": "^14.3.1",
     "tape": "^4.6.3",
@@ -78,9 +76,6 @@
     "useragent": "^2.3.0",
     "uuid": "^3.0.1",
     "winston": "^2.3.0"
-  },
-  "resolutions": {
-    "minimist": "1.2.3"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Strategy attempted in https://github.com/brave/security/issues/101 caused complexities with `brave-core-crx-packager` (via `https-everywhere-updater`) unfortunately, through the tangled mess of dependencies ☹️ 

----------

Revert "Merge pull request #375 from brave/bsc-fix-npm"

This reverts commit f4b71bac02bde90178bf6b9c25c5d54e690a3c08, reversing
changes made to 4428f605acd31542387bfa8956dda28becaec650.